### PR TITLE
feat: make smartcards default feature and musl default target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
+[build]
+# Default to musl target for static builds
+target = "x86_64-unknown-linux-musl"
+
 [target.x86_64-unknown-linux-musl]
-linker = "x86_64-unknown-linux-musl-gcc"
-rustflags = ["-C", "target-feature=+crt-static"]
+# Use the linker from the nix shell environment
+linker = "x86_64-unknown-linux-musl-cc"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,14 +52,20 @@ jobs:
     - name: Run linting
       run: nix develop -c cargo clippy -- -D warnings
     
-    - name: Build with glibc and all features
-      run: nix develop -c cargo build -F smartcards
+    - name: Build default (musl with smartcards)
+      run: nix develop -c cargo build
     
-    - name: Build with musl and only default features
-      run: nix develop -c cargo build --target x86_64-unknown-linux-musl
+    - name: Build without smartcards
+      run: nix develop -c cargo build --no-default-features
     
-    - name: Run tests with glibc and all features
-      run: nix develop -c cargo test -F smartcards
+    - name: Build for native target with smartcards
+      run: nix develop -c cargo build --target x86_64-unknown-linux-gnu
     
-    - name: Run tests with musl and only default features
-      run: nix develop -c cargo test --target x86_64-unknown-linux-musl
+    - name: Run tests (musl with smartcards)
+      run: nix develop -c cargo test
+    
+    - name: Run tests without smartcards
+      run: nix develop -c cargo test --no-default-features
+    
+    - name: Build with nix (static musl binary)
+      run: nix build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cktap-direct"
+version = "0.1.0"
+source = "git+https://github.com/douglaz/cktap-direct#7b5c4be65a24042bedf3834821c403c2b48d65de"
+dependencies = [
+ "bitcoin",
+ "ciborium",
+ "log",
+ "rusb",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.12",
+ "tokio",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,14 +370,14 @@ dependencies = [
  "base64",
  "bech32 0.9.1",
  "bitcoin",
+ "cktap-direct",
  "clap",
  "fedimint-lite",
  "hex",
  "lightning-invoice",
- "pcsc",
  "rand 0.8.5",
  "reqwest",
- "rust-cktap",
+ "rusb",
  "secp256k1",
  "serde",
  "serde_json",
@@ -801,6 +816,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libusb1-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da050ade7ac4ff1ba5379af847a10a10a8e284181e060105bf8d86960ce9ce0f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "lightning-invoice"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,25 +944,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
-]
-
-[[package]]
-name = "pcsc"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd833ecf8967e65934c49d3521a175929839bf6d0e497f3bd0d3a2ca08943da"
-dependencies = [
- "bitflags",
- "pcsc-sys",
-]
-
-[[package]]
-name = "pcsc-sys"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ef017e15d2e5592a9e39a346c1dbaea5120bab7ed7106b210ef58ebd97003"
-dependencies = [
- "pkg-config",
 ]
 
 [[package]]
@@ -1180,18 +1188,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-cktap"
-version = "0.1.0"
-source = "git+https://github.com/notmandatory/rust-cktap?rev=0016e3c6ac48a34ea7dedd07b1d88b955c57d466#0016e3c6ac48a34ea7dedd07b1d88b955c57d466"
+name = "rusb"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9f9ff05b63a786553a4c02943b74b34a988448671001e9a27e2f0565cc05a4"
 dependencies = [
- "bitcoin",
- "ciborium",
- "log",
- "pcsc",
- "serde",
- "serde_bytes",
- "thiserror 2.0.12",
- "tokio",
+ "libc",
+ "libusb1-sys",
 ]
 
 [[package]]
@@ -1679,6 +1682,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/cyberkrill/Cargo.toml
+++ b/cyberkrill/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = []
-smartcards = ["rust-cktap", "pcsc"]
+default = ["smartcards"]
+smartcards = ["cktap-direct", "rusb"]
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }
@@ -21,9 +21,9 @@ url = "2.5.0"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tokio = { version = "1.0", features = ["full"] }
 fedimint-lite = { path = "../fedimint-lite" }
-# Tapsigner support (optional feature)
-rust-cktap = { git = "https://github.com/notmandatory/rust-cktap", rev = "0016e3c6ac48a34ea7dedd07b1d88b955c57d466", features = ["pcsc"], optional = true }
-pcsc = { version = "2.8", optional = true }
+# Tapsigner/Satscard support via USB (optional feature)
+cktap-direct = { git = "https://github.com/douglaz/cktap-direct", optional = true }
+rusb = { version = "0.9", optional = true }
 bitcoin = "0.32"
 secp256k1 = "0.29"
 rand = "0.8"

--- a/cyberkrill/src/satscard.rs
+++ b/cyberkrill/src/satscard.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 // Satscard imports - correct API usage
 use bitcoin::{key::CompressedPublicKey, network::Network, Address};
-use rust_cktap::commands::Read;
-use rust_cktap::{pcsc::find_first, CkTapCard}; // Required trait import for read() method
+use cktap_direct::commands::Read;
+use cktap_direct::{discovery::find_first, CkTapCard}; // Required trait import for read() method
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SatscardAddressOutput {
@@ -30,7 +30,7 @@ pub async fn generate_satscard_address(slot: Option<u8>) -> Result<SatscardAddre
     // Connect to Satscard via NFC/PCSC - this automatically gets status
     let card = find_first()
         .await
-        .with_context(|| "Failed to find Satscard. Make sure PCSC daemon is running, NFC reader is connected, and Satscard is placed on the reader")?;
+        .with_context(|| "Failed to find Satscard. Make sure your USB card reader is connected and Satscard is placed on the reader")?;
 
     let mut satscard = match card {
         CkTapCard::SatsCard(satscard) => satscard,

--- a/cyberkrill/src/tapsigner.rs
+++ b/cyberkrill/src/tapsigner.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+use crate::satscard::{SatscardAddressOutput, SatscardInfo};
+
 // Tapsigner imports
 use bitcoin::{
     bip32::{DerivationPath, Xpub},
@@ -552,6 +554,14 @@ mod tests {
                 .to_string(),
             derivation_path: "m/0".to_string(),
             is_used: false,
+            card_info: SatscardInfo {
+                proto: 1,
+                ver: "1.0.0".to_string(),
+                birth: 750000,
+                current_slot: 0,
+                max_slot: 9,
+                card_address: None,
+            },
         };
 
         // Test JSON serialization

--- a/cyberkrill/src/tapsigner.rs
+++ b/cyberkrill/src/tapsigner.rs
@@ -34,7 +34,6 @@ pub struct TapsignerInitOutput {
     pub birth_block: usize,
 }
 
-
 pub async fn generate_tapsigner_address(path: &str) -> Result<TapsignerAddressOutput> {
     // Parse the derivation path and split into hardened/non-hardened parts
     let (hardened_path, non_hardened_path) = split_derivation_path(path)?;
@@ -228,7 +227,10 @@ impl<T: cktap_direct::commands::CkTransport> TapsignerDevice<T> {
                     .await
                     .with_context(|| "Failed to derive key from Tapsigner")?;
                 Ok(DeriveResult {
-                    pubkey: derive_response.pubkey.unwrap_or(derive_response.master_pubkey).to_vec(),
+                    pubkey: derive_response
+                        .pubkey
+                        .unwrap_or(derive_response.master_pubkey)
+                        .to_vec(),
                     chain_code: derive_response.chain_code.to_vec(),
                 })
             }
@@ -251,7 +253,8 @@ async fn connect_tapsigner() -> Result<TapsignerDevice<cktap_direct::usb_transpo
     }
 }
 
-async fn connect_tapsigner_direct() -> Result<TapSigner<cktap_direct::usb_transport::UsbTransport>> {
+async fn connect_tapsigner_direct() -> Result<TapSigner<cktap_direct::usb_transport::UsbTransport>>
+{
     // Find and connect to the first available CkTap card - direct access for initialization
     let card = find_first()
         .await

--- a/cyberkrill/src/tapsigner.rs
+++ b/cyberkrill/src/tapsigner.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+#[cfg(test)]
 use crate::satscard::{SatscardAddressOutput, SatscardInfo};
 
 // Tapsigner imports

--- a/flake.nix
+++ b/flake.nix
@@ -15,13 +15,20 @@
           overlays = [ (import rust-overlay) ];
         };
         
+        
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" ];
           targets = [ "x86_64-unknown-linux-musl" ];
         };
       in
       {
-        packages.default = pkgs.rustPlatform.buildRustPackage {
+        # Default package: static musl build with smartcards
+        packages.default = let
+          rustPlatformMusl = pkgs.makeRustPlatform {
+            cargo = rustToolchain;
+            rustc = rustToolchain;
+          };
+        in rustPlatformMusl.buildRustPackage {
           pname = "cyberkrill";
           version = "0.1.0";
           src = ./.;
@@ -29,7 +36,67 @@
           cargoLock = {
             lockFile = ./Cargo.lock;
             outputHashes = {
-              "rust-cktap-0.1.0" = "sha256-vO26qr9I5U96SgtTKSiKKqVHcO/T+RXSKeb8JCOcYOI=";
+              "cktap-direct-0.1.0" = "sha256-ddQhghrmtwXKr750bTzjolSDLwyNZFUskNhJrR2vyBo=";
+            };
+          };
+          
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            rustToolchain
+            pkgsStatic.stdenv.cc
+          ];
+          
+          buildInputs = with pkgs.pkgsStatic; [
+            libusb1
+          ];
+          
+          # Environment variables for static libusb
+          LIBUSB_STATIC = "1";
+          PKG_CONFIG_PATH = "${pkgs.pkgsStatic.libusb1}/lib/pkgconfig";
+          
+          # Build with smartcards feature by default
+          buildFeatures = [ "smartcards" ];
+          
+          # Force cargo to use the musl target from .cargo/config.toml
+          CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";
+          CC_x86_64_unknown_linux_musl = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";
+          CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C link-arg=-static";
+          
+          # Override cargo target dir to use musl subdirectory
+          preBuild = ''
+            export CARGO_TARGET_DIR="target"
+          '';
+          
+          # Ensure static linking
+          doCheck = false; # Tests don't work well with static linking
+          
+          # Verify the binary is statically linked
+          postInstall = ''
+            echo "Checking if binary is statically linked..."
+            file $out/bin/cyberkrill
+            # Strip the binary to reduce size
+            ${pkgs.binutils}/bin/strip $out/bin/cyberkrill
+          '';
+          
+          meta = with pkgs.lib; {
+            description = "CLI utility for Bitcoin and Lightning Network operations";
+            homepage = "https://github.com/douglaz/cyberkrill";
+            license = licenses.mit;
+            maintainers = [ ];
+          };
+        };
+        
+        # Alternative dynamic build (non-static)
+        packages.cyberkrill-dynamic = pkgs.rustPlatform.buildRustPackage {
+          pname = "cyberkrill-dynamic";
+          version = "0.1.0";
+          src = ./.;
+          
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "cktap-direct-0.1.0" = "sha256-ddQhghrmtwXKr750bTzjolSDLwyNZFUskNhJrR2vyBo=";
             };
           };
           
@@ -39,14 +106,14 @@
           ];
           
           buildInputs = with pkgs; [
-            pcsclite
+            libusb1
           ];
           
-          # Build without smartcards feature by default for broader compatibility
-          buildFeatures = [ ];
+          # Build with smartcards feature by default
+          buildFeatures = [ "smartcards" ];
           
           meta = with pkgs.lib; {
-            description = "CLI utility for Bitcoin and Lightning Network operations";
+            description = "CLI utility for Bitcoin and Lightning Network operations (dynamic build)";
             homepage = "https://github.com/douglaz/cyberkrill";
             license = licenses.mit;
             maintainers = [ ];
@@ -59,11 +126,21 @@
             rustToolchain
             pkg-config
             pkgsStatic.stdenv.cc
-            pcsclite
+            libusb1
+            pkgsStatic.libusb1
           ];
 
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";
           CC_x86_64_unknown_linux_musl = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";
+          
+          # For static linking with musl
+          LIBUSB_STATIC = "1";
+          PKG_CONFIG_PATH = "${pkgs.pkgsStatic.libusb1}/lib/pkgconfig";
+          
+          # Add static libusb to the shell
+          shellHook = ''
+            export RUSTFLAGS="-L ${pkgs.pkgsStatic.libusb1}/lib"
+          '';
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,7 @@
             pkgsStatic.stdenv.cc
             libusb1
             pkgsStatic.libusb1
+            gh
           ];
 
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";


### PR DESCRIPTION
## Summary
- Replace rust-cktap with cktap-direct for USB-based smartcard support
- Enable static musl compilation by default for portable binaries
- Make smartcards feature part of default features

## Changes
- **Smartcard library migration**: Switched from `rust-cktap` (PCSC-based) to `cktap-direct` (USB-based) for better static compilation support
- **Default musl target**: Added `.cargo/config.toml` to set `x86_64-unknown-linux-musl` as the default build target
- **Static linking**: Updated `flake.nix` to properly link libusb statically for musl builds
- **Default features**: Made `smartcards` a default feature in `Cargo.toml`
- **Flake improvements**: Default package now builds a fully static musl binary with smartcard support

## Breaking Changes
- Default build target is now `x86_64-unknown-linux-musl` (was native target)
- Smartcard support now uses USB communication instead of PCSC (no longer requires `pcscd` service)

## Benefits
- Single portable binary that works across different Linux distributions
- No runtime dependencies on PCSC libraries or services
- Smaller deployment footprint
- Better suited for containerized environments

## Test Plan
- [x] Build with `nix develop -c cargo build` (uses musl by default)
- [x] Build with `nix build` (creates static binary)
- [x] Test Tapsigner functionality with hardware
- [x] Test Satscard functionality with hardware
- [x] Verify static linking with `file` command
- [x] Test on system without PCSC installed