### PR TITLE
docs: clarify PSBT command distinctions in CLI help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ cyberkrill satscard-address -o satscard_address.json
 
 ### Bitcoin Core RPC Operations
 
+CyberKrill provides three distinct commands for creating PSBTs (Partially Signed Bitcoin Transactions), each designed for different use cases:
+
+#### PSBT Creation Commands - Key Differences
+
+| Command | Input Selection | Output Specification | Change Handling | Primary Use Case |
+|---------|----------------|---------------------|-----------------|------------------|
+| **`create-psbt`** | Manual - you specify exact UTXOs | Manual - you specify all outputs including change | Manual - you calculate and add change output | Full control transactions |
+| **`create-funded-psbt`** | Automatic - wallet selects optimal inputs | Manual - you specify recipient outputs only | Automatic - wallet adds change output | Standard send transactions |
+| **`move-utxos`** | Manual - you specify UTXOs to consolidate | Automatic - single output (total - fee) | N/A - all funds go to destination | UTXO consolidation |
+
+**Quick Guide:**
+- **`create-psbt`**: Use when you need complete control over every aspect of the transaction
+- **`create-funded-psbt`**: Use for typical "send payment" scenarios where you want the wallet to handle complexity
+- **`move-utxos`**: Use specifically for consolidating UTXOs or moving all funds from specific inputs
+
 #### List UTXOs
 
 ```bash
@@ -139,10 +154,12 @@ cyberkrill list-utxos --bitcoin-dir /path/to/.bitcoin --descriptor "wpkh([finger
 cyberkrill list-utxos --rpc-user myuser --rpc-password mypass --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)"
 ```
 
-#### Create PSBT (Partially Signed Bitcoin Transaction)
+#### Create PSBT (Manual Transaction Building)
+
+**When to use**: When you need complete control over every aspect of the transaction - which UTXOs to spend, exact output amounts, and manual change calculation. Perfect for advanced use cases like specific UTXO selection for privacy or when implementing custom transaction logic.
 
 ```bash
-# Create PSBT with manual inputs/outputs
+# Create PSBT with manual inputs/outputs - you calculate change yourself
 cyberkrill create-psbt \
   --inputs "txid1:0" --inputs "txid2:1" \
   --outputs "bc1qaddr1:0.001,bc1qaddr2:0.002" \
@@ -169,10 +186,12 @@ cyberkrill create-psbt \
   --psbt-output transaction.psbt
 ```
 
-#### Create Funded PSBT (Automatic Input Selection)
+#### Create Funded PSBT (Automatic Input Selection & Change)
+
+**When to use**: For standard "send payment" transactions where you want Bitcoin Core to handle the complexity. The wallet automatically selects optimal inputs, calculates fees, and adds a change output. This is the recommended approach for most payment scenarios.
 
 ```bash
-# Let Bitcoin Core select inputs automatically
+# Let Bitcoin Core select inputs and handle change automatically
 cyberkrill create-funded-psbt \
   --outputs "bc1qaddr1:0.001,bc1qaddr2:0.002" \
   --conf-target 6 \
@@ -200,8 +219,10 @@ cyberkrill create-funded-psbt \
 
 #### Consolidate UTXOs (Move UTXOs)
 
+**When to use**: Specifically for UTXO consolidation or moving all funds from selected inputs to a single destination. Unlike the other commands, you don't specify output amounts - the command automatically sends (total input value - fee) to the destination address. Perfect for cleaning up fragmented UTXOs or emptying specific addresses.
+
 ```bash
-# Consolidate specific UTXOs to single address
+# Consolidate specific UTXOs to single address - output = inputs - fee
 cyberkrill move-utxos \
   --inputs "txid1:0" --inputs "txid2:1" --inputs "txid3:0" \
   --destination "bc1qconsolidated_address" \

--- a/cyberkrill/src/main.rs
+++ b/cyberkrill/src/main.rs
@@ -46,15 +46,15 @@ enum Commands {
     // Bitcoin RPC Operations
     #[command(about = "List UTXOs for addresses or descriptors")]
     ListUtxos(ListUtxosArgs),
-    #[command(about = "Create PSBT with manual input/output specification")]
+    #[command(about = "Create PSBT with manual input/output specification (you specify exact inputs, outputs, and change)")]
     CreatePsbt(CreatePsbtArgs),
-    #[command(about = "Create funded PSBT with automatic input selection")]
+    #[command(about = "Create funded PSBT with automatic input selection and change output (wallet handles coin selection)")]
     CreateFundedPsbt(CreateFundedPsbtArgs),
-    #[command(about = "Consolidate/move UTXOs to a destination address")]
+    #[command(about = "Consolidate/move UTXOs to a single destination address (output = total inputs - fee)")]
     MoveUtxos(MoveUtxosArgs),
 
     // BDK Wallet Operations
-    #[command(about = "List UTXOs using BDK wallet (no blockchain connection)")]
+    #[command(about = "List UTXOs using BDK wallet (supports Bitcoin Core, Electrum backends, or local wallet)")]
     BdkListUtxos(BdkListUtxosArgs),
 }
 


### PR DESCRIPTION
## Summary
This PR improves the CLI help text to clearly distinguish between the three PSBT creation commands.

## Changes
- Updated `create-psbt` help: "Create PSBT with manual input/output specification (you specify exact inputs, outputs, and change)"
- Updated `create-funded-psbt` help: "Create funded PSBT with automatic input selection and change output (wallet handles coin selection)"
- Updated `move-utxos` help: "Consolidate/move UTXOs to a single destination address (output = total inputs - fee)"

## Context
This change addresses user feedback about the unclear distinctions between these commands. The updated help text immediately communicates the key difference:
- `create-psbt`: You control everything manually
- `create-funded-psbt`: Wallet handles coin selection automatically
- `move-utxos`: Specifically for consolidation (no explicit outputs)

## Test Plan
- [x] Verified help text displays correctly with `--help`
- [x] No functional changes, only documentation