### PR TITLE
style: fix string interpolation to follow project conventions

### DIFF
--- a/cyberkrill-core/src/bdk_wallet.rs
+++ b/cyberkrill-core/src/bdk_wallet.rs
@@ -284,10 +284,10 @@ pub async fn scan_and_list_utxos_bitcoind(
                     let script = bitcoin::ScriptBuf::from(script_bytes);
                     match bitcoin::Address::from_script(&script, _network) {
                         Ok(addr) => addr.to_string(),
-                        Err(_) => format!("script:{}", utxo.script_pub_key), // Fallback to script hex
+                        Err(_) => format!("script:{script}", script = utxo.script_pub_key), // Fallback to script hex
                     }
                 }
-                Err(_) => format!("script:{}", utxo.script_pub_key), // Fallback to script hex
+                Err(_) => format!("script:{script}", script = utxo.script_pub_key), // Fallback to script hex
             }
         };
 

--- a/cyberkrill-core/src/bitcoin_rpc.rs
+++ b/cyberkrill-core/src/bitcoin_rpc.rs
@@ -428,7 +428,7 @@ impl BitcoinRpcClient {
         let response = request.send().await?;
 
         if !response.status().is_success() {
-            bail!("HTTP error: {}", response.status());
+            bail!("HTTP error: {status}", status = response.status());
         }
 
         let json: serde_json::Value = response.json().await?;
@@ -808,7 +808,7 @@ impl BitcoinRpcClient {
             let change_descriptor = format!("{before}1{after}");
             Ok(change_descriptor)
         } else {
-            bail!("Descriptor does not contain <0;1> syntax: {}", descriptor);
+            bail!("Descriptor does not contain <0;1> syntax: {descriptor}");
         }
     }
 
@@ -882,7 +882,7 @@ impl BitcoinRpcClient {
             }
         }
 
-        bail!("Failed to derive address from descriptor: {}", descriptor);
+        bail!("Failed to derive address from descriptor: {descriptor}");
     }
 
     /// Checks if an address has any UTXOs (used or unused).

--- a/cyberkrill-core/src/tapsigner.rs
+++ b/cyberkrill-core/src/tapsigner.rs
@@ -436,11 +436,7 @@ mod tests {
 
         for path in invalid_paths {
             let result = parse_derivation_path(path);
-            assert!(
-                result.is_err(),
-                "Path '{path}' should be invalid",
-                path = path
-            );
+            assert!(result.is_err(), "Path '{path}' should be invalid");
         }
         Ok(())
     }
@@ -579,16 +575,12 @@ mod tests {
 
         // Valid slots
         for slot in 0..=9 {
-            assert!(slot <= max_slot, "Slot {slot} should be valid", slot = slot);
+            assert!(slot <= max_slot, "Slot {slot} should be valid");
         }
 
         // Invalid slots
         for slot in 10..=20 {
-            assert!(
-                slot > max_slot,
-                "Slot {slot} should be invalid",
-                slot = slot
-            );
+            assert!(slot > max_slot, "Slot {slot} should be invalid");
         }
     }
 

--- a/cyberkrill/src/main.rs
+++ b/cyberkrill/src/main.rs
@@ -46,15 +46,23 @@ enum Commands {
     // Bitcoin RPC Operations
     #[command(about = "List UTXOs for addresses or descriptors")]
     ListUtxos(ListUtxosArgs),
-    #[command(about = "Create PSBT with manual input/output specification (you specify exact inputs, outputs, and change)")]
+    #[command(
+        about = "Create PSBT with manual input/output specification (you specify exact inputs, outputs, and change)"
+    )]
     CreatePsbt(CreatePsbtArgs),
-    #[command(about = "Create funded PSBT with automatic input selection and change output (wallet handles coin selection)")]
+    #[command(
+        about = "Create funded PSBT with automatic input selection and change output (wallet handles coin selection)"
+    )]
     CreateFundedPsbt(CreateFundedPsbtArgs),
-    #[command(about = "Consolidate/move UTXOs to a single destination address (output = total inputs - fee)")]
+    #[command(
+        about = "Consolidate/move UTXOs to a single destination address (output = total inputs - fee)"
+    )]
     MoveUtxos(MoveUtxosArgs),
 
     // BDK Wallet Operations
-    #[command(about = "List UTXOs using BDK wallet (supports Bitcoin Core, Electrum backends, or local wallet)")]
+    #[command(
+        about = "List UTXOs using BDK wallet (supports Bitcoin Core, Electrum backends, or local wallet)"
+    )]
     BdkListUtxos(BdkListUtxosArgs),
 }
 
@@ -321,10 +329,13 @@ struct BdkListUtxosArgs {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Initialize rustls crypto provider for TLS connections (required for Electrum)
-    if let Err(_) = rustls::crypto::ring::default_provider().install_default() {
+    if rustls::crypto::ring::default_provider()
+        .install_default()
+        .is_err()
+    {
         bail!("Failed to initialize rustls crypto provider");
     }
-    
+
     let args: Cli = Cli::parse();
     match args.command {
         // Lightning Network Operations

--- a/fedimint-lite/src/lib.rs
+++ b/fedimint-lite/src/lib.rs
@@ -107,7 +107,7 @@ fn parse_consensus_encoding(bytes: &[u8], encoding_format: &str) -> Result<Fedim
 
     for i in 0..num_parts {
         if pos >= bytes.len() {
-            anyhow::bail!("Unexpected end of data at part {}", i);
+            anyhow::bail!("Unexpected end of data at part {i}");
         }
 
         // Read variant discriminator (VarInt)
@@ -160,7 +160,7 @@ fn parse_consensus_encoding(bytes: &[u8], encoding_format: &str) -> Result<Fedim
                 pos += bytes_read;
 
                 if fed_id_len != 32 {
-                    anyhow::bail!("Federation ID length should be 32, got {}", fed_id_len);
+                    anyhow::bail!("Federation ID length should be 32, got {fed_id_len}");
                 }
 
                 if pos + 32 > bytes.len() {
@@ -216,7 +216,7 @@ fn parse_consensus_encoding(bytes: &[u8], encoding_format: &str) -> Result<Fedim
 // Read BigSize VarInt at specific position, returns (value, bytes_consumed)
 fn read_varint_at(bytes: &[u8], pos: usize) -> Result<(u64, usize)> {
     if pos >= bytes.len() {
-        anyhow::bail!("Position {} exceeds buffer length {}", pos, bytes.len());
+        anyhow::bail!("Position {pos} exceeds buffer length {}", bytes.len());
     }
 
     let first_byte = bytes[pos];
@@ -287,7 +287,7 @@ pub fn encode_fedimint_invite(invite: &FedimintInviteOutput) -> Result<String> {
     // Only support bech32m format
     let format = invite.encoding_format.as_str();
     if format != "bech32m" {
-        anyhow::bail!("Only bech32m encoding format is supported, got: {}", format);
+        anyhow::bail!("Only bech32m encoding format is supported, got: {format}");
     }
 
     // Build the consensus-encoded bytes
@@ -486,7 +486,7 @@ pub async fn fetch_fedimint_config(invite_code: &str) -> Result<FederationConfig
                 return parse_federation_config(config, &invite);
             }
             Err(e) => {
-                eprintln!("Failed to fetch config from {}: {}", guardian.url, e);
+                eprintln!("Failed to fetch config from {}: {e}", guardian.url);
                 last_error = Some(e);
                 continue;
             }
@@ -521,7 +521,10 @@ async fn fetch_config_from_guardian(
     };
 
     if !response.status().is_success() {
-        anyhow::bail!("HTTP request failed with status: {}", response.status());
+        anyhow::bail!(
+            "HTTP request failed with status: {status}",
+            status = response.status()
+        );
     }
 
     let config: serde_json::Value = response


### PR DESCRIPTION
## Summary
This PR fixes string interpolation patterns throughout the codebase to follow the conventions outlined in CONVENTIONS.md.

## Changes
- **fedimint-lite**: Update `bail\!` statements to use direct variable interpolation
- **bitcoin_rpc.rs**: Fix error messages to follow interpolation conventions
- **bdk_wallet.rs**: Use named parameters for `format\!` when calling methods
- **tapsigner.rs**: Remove redundant named parameters in test assertions (clippy fix)
- **main.rs**: Improve rustls error handling using `.is_err()` instead of `if let Err(_)` (clippy suggestion)

## Convention Applied
According to CONVENTIONS.md:
1. Use direct variable names when the variable name matches the placeholder: `{variable}`
2. Use named parameters for method calls or when you want a different name: `{name}`, name = value.method()
3. Never create temporary variables just for string interpolation

## Test Plan
- [x] All tests pass: `cargo test`
- [x] No clippy warnings: `cargo clippy`
- [x] Code properly formatted: `cargo fmt --check`
- [x] Quality check sequence passes: `cargo test && cargo clippy && cargo fmt --check`

## Example Changes
```rust
// Before
bail\!("Unexpected end of data at part {}", i);

// After
bail\!("Unexpected end of data at part {i}");
```

```rust
// Before (method call)
format\!("script:{}", utxo.script_pub_key)

// After (named parameter for method result)
format\!("script:{script}", script = utxo.script_pub_key)
```