### PR TITLE
feat(bdk): add Esplora backend support for BDK wallet operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,12 +272,28 @@ cyberkrill move-utxos \
 
 ### BDK Wallet Operations (Bitcoin Development Kit)
 
-CyberKrill includes BDK 2.0 integration for working with Bitcoin descriptors and UTXOs. The `bdk-list-utxos` command provides an alternative way to list UTXOs using BDK's wallet functionality.
+CyberKrill includes BDK 2.0 integration for working with Bitcoin descriptors and UTXOs. The `bdk-list-utxos` command provides an alternative way to list UTXOs using BDK's wallet functionality with support for multiple blockchain backends.
 
 #### List UTXOs with BDK
 
+**Backend Options:**
+- **Electrum**: Fast and lightweight blockchain queries
+- **Esplora**: RESTful API for blockchain data (no authentication required)
+- **Bitcoin Core**: Direct RPC connection to your Bitcoin node
+- **Local**: BDK wallet without blockchain connection (offline mode)
+
 ```bash
-# List UTXOs using BDK with Bitcoin Core backend
+# Using Electrum backend (fast and lightweight)
+cyberkrill bdk-list-utxos \
+  --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)" \
+  --electrum ssl://electrum.blockstream.info:50002
+
+# Using Esplora backend (REST API, no auth required)
+cyberkrill bdk-list-utxos \
+  --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)" \
+  --esplora https://blockstream.info/api
+
+# Using Bitcoin Core backend (requires local node)
 cyberkrill bdk-list-utxos \
   --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)" \
   --bitcoin-dir ~/libre
@@ -285,14 +301,27 @@ cyberkrill bdk-list-utxos \
 # With multipath descriptors (automatically expanded)
 cyberkrill bdk-list-utxos \
   --descriptor "wpkh([fingerprint/84'/0'/0']xpub.../<0;1>/*)" \
-  --bitcoin-dir ~/.bitcoin
+  --electrum ssl://electrum.blockstream.info:50002
 
 # Complex multisig with multipath
 cyberkrill bdk-list-utxos \
   --descriptor "wsh(sortedmulti(4,xpub1/<0;1>/*,xpub2/<0;1>/*,...))" \
-  --bitcoin-dir ~/libre
+  --esplora https://blockstream.info/api
 
-# Different networks
+# Different networks with appropriate backends
+# Testnet with Esplora
+cyberkrill bdk-list-utxos \
+  --descriptor "wpkh([fingerprint/84'/1'/0']tpub...)" \
+  --network testnet \
+  --esplora https://blockstream.info/testnet/api
+
+# Testnet with Electrum
+cyberkrill bdk-list-utxos \
+  --descriptor "wpkh([fingerprint/84'/1'/0']tpub...)" \
+  --network testnet \
+  --electrum ssl://electrum.blockstream.info:60002
+
+# Testnet with Bitcoin Core
 cyberkrill bdk-list-utxos \
   --descriptor "wpkh([fingerprint/84'/1'/0']tpub...)" \
   --network testnet \
@@ -301,7 +330,7 @@ cyberkrill bdk-list-utxos \
 # Save output to file
 cyberkrill bdk-list-utxos \
   --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)" \
-  --bitcoin-dir ~/libre \
+  --esplora https://blockstream.info/api \
   --output utxos.json
 ```
 

--- a/cyberkrill-core/src/lib.rs
+++ b/cyberkrill-core/src/lib.rs
@@ -23,7 +23,7 @@ pub use bitcoin_rpc::{AmountInput, BitcoinRpcClient};
 
 pub use bdk_wallet::{
     get_utxo_summary, list_utxos_bdk, scan_and_list_utxos_bitcoind, scan_and_list_utxos_electrum,
-    BdkUtxo, BdkUtxoSummary,
+    scan_and_list_utxos_esplora, BdkUtxo, BdkUtxoSummary,
 };
 
 // Re-export bitcoin types needed by CLI


### PR DESCRIPTION
## Summary
This PR adds Esplora as a third backend option for the `bdk-list-utxos` command, alongside the existing Electrum and Bitcoin Core RPC backends. Esplora provides a RESTful API for blockchain data access without requiring authentication.

## Changes
- Added `--esplora` CLI argument with mutual exclusivity against other backends
- Implemented `scan_and_list_utxos_esplora` function in `bdk_wallet.rs`
- Exported the new function in `lib.rs` for external library usage
- Updated README.md with comprehensive Esplora examples for all networks
- Updated command help text to mention all three backend options

## Technical Details
- Uses `bdk_esplora` crate with blocking client for consistency with other backends
- Follows the same implementation pattern as Electrum backend
- Handles multipath descriptor expansion (`<0;1>/*` syntax)
- Provides progress output during scanning
- Gracefully handles rate limiting and other errors

## Test Plan
- [x] Reviewed code against CONVENTIONS.md
- [x] cargo fmt - code formatted
- [x] cargo clippy - no warnings
- [x] cargo test - all tests pass
- [x] Manual testing completed with mainnet descriptor
- [x] Verified rate limiting is handled gracefully
- [x] Tested multipath descriptor expansion

## Breaking Changes
None - this is a purely additive change that maintains backward compatibility.

## Example Usage
```bash
# Mainnet
cyberkrill bdk-list-utxos --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)" --esplora https://blockstream.info/api

# Testnet
cyberkrill bdk-list-utxos --descriptor "wpkh([fingerprint/84'/1'/0']tpub...)" --network testnet --esplora https://blockstream.info/testnet/api
```