### PR TITLE
feat: add frozenkrill wallet support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +43,26 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "alkali"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb2e727d77155f0e96b81253095e40dfbd3a8eb33b5b9a01bb881dbca9f3992"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "libsodium-sys-stable",
+ "rand_core 0.6.4",
+ "serde",
+ "serde-big-array",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -96,6 +122,21 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 dependencies = [
  "backtrace",
 ]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -175,8 +216,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
@@ -210,7 +251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17698c25d2728afd6950d82069dce172147006f73960b9dc793a7e8dd7089016"
 dependencies = [
  "bitcoin",
- "hashbrown",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -269,7 +310,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -284,6 +325,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "2.2.0"
+source = "git+https://github.com/rust-bitcoin/rust-bip39#5bb47117ba8d6c8d7f2fc601cfae78ef2cda643e"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
+ "zeroize",
+]
+
+[[package]]
 name = "bitcoin"
 version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,15 +346,21 @@ dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32 0.11.0",
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
  "hex_lit",
  "secp256k1",
  "serde",
 ]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-internals"
@@ -323,8 +383,18 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
 ]
 
 [[package]]
@@ -334,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.1",
  "serde",
 ]
 
@@ -343,6 +413,20 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "rayon-core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -512,6 +596,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +618,40 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -562,6 +695,7 @@ dependencies = [
  "bitcoin",
  "cktap-direct",
  "fedimint-lite",
+ "frozenkrill-core",
  "hex",
  "lightning-invoice",
  "rand 0.8.5",
@@ -571,9 +705,27 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -627,6 +779,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,11 +814,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0af349d96a5d9ad77ba59f1437aa6f348b03c5865d4f7d6e7a662d60aedce39"
 dependencies = [
  "bitcoin",
- "hex-conservative",
+ "hex-conservative 0.2.1",
  "log",
  "minreq",
  "serde",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-lite"
@@ -664,6 +841,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +875,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "frozenkrill-core"
+version = "0.0.0"
+source = "git+https://github.com/planktonlabs/frozenkrill#7b84158ce162f4f5d269c8340e99d052c28b4e51"
+dependencies = [
+ "alkali",
+ "anyhow",
+ "bip39",
+ "bitcoin",
+ "blake3",
+ "env_logger",
+ "flate2",
+ "hex",
+ "itertools 0.13.0",
+ "libsodium-sys-stable",
+ "log",
+ "miniscript",
+ "once_cell",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rayon",
+ "regex",
+ "secp256k1",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "walkdir",
+ "zeroize",
 ]
 
 [[package]]
@@ -783,14 +1014,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -800,6 +1044,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
@@ -864,6 +1114,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -1033,6 +1289,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.4",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1326,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1347,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1119,6 +1405,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libflate"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1436,34 @@ checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "libsodium-sys-stable"
+version = "1.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b023d38f2afdfe36f81e15a9d7232097701d7b107e3a93ba903083985e235239"
+dependencies = [
+ "cc",
+ "libc",
+ "libflate",
+ "minisign-verify",
+ "pkg-config",
+ "tar",
+ "ureq",
+ "vcpkg",
+ "zip",
 ]
 
 [[package]]
@@ -1166,6 +1504,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1217,6 +1561,12 @@ dependencies = [
  "bitcoin",
  "serde",
 ]
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43"
 
 [[package]]
 name = "miniz_oxide"
@@ -1498,10 +1848,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.15"
+name = "rayon"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -1588,6 +1958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "rusb"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,7 +2000,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1701,6 +2090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,7 +2120,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "rand 0.8.5",
  "secp256k1-sys",
  "serde",
@@ -1738,12 +2136,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1815,6 +2231,12 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
@@ -1895,6 +2317,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2110,10 +2565,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "url",
+]
 
 [[package]]
 name = "url"
@@ -2149,6 +2625,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2289,7 +2775,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -2307,6 +2793,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2412,6 +2907,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
+name = "xattr"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+dependencies = [
+ "libc",
+ "rustix 1.0.8",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,6 +2986,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -2513,4 +3032,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.12",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A comprehensive CLI toolkit for Bitcoin and Lightning Network operations, writte
 - **Sub-satoshi Precision**: Support for fractional satoshi fee rates (e.g., "0.1sats/vB") using millisatoshi precision
 - **Smart Coin Selection**: Automatic coin selection with max-amount limits and descriptor-based input selection
 - **Output Descriptor Support**: Use descriptors as inputs with automatic UTXO discovery and change address derivation
+- **frozenkrill Wallet Support**: Import and use frozenkrill wallet export files instead of raw descriptors
 - **JSON Output**: All commands output structured JSON for easy integration with other tools
 
 ## Installation
@@ -165,6 +166,9 @@ cyberkrill list-utxos --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)" \
 
 # Using specific addresses with Bitcoin Core
 cyberkrill list-utxos --addresses "bc1qtest1,bc1qtest2"
+
+# Using frozenkrill wallet export file
+cyberkrill list-utxos --wallet-file mywallet_pub.json
 
 # Custom Bitcoin directory
 cyberkrill list-utxos --bitcoin-dir /path/to/.bitcoin --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)"
@@ -397,6 +401,32 @@ Then use:
 ```bash
 cyberkrill list-utxos --rpc-user myuser --rpc-password mypassword --descriptor "wpkh([...]xpub...)"
 ```
+
+### frozenkrill Wallet Integration
+
+CyberKrill supports frozenkrill wallet export files as an alternative to raw descriptors. This provides a more user-friendly way to work with wallets that have pre-generated addresses and metadata.
+
+**Using frozenkrill wallet files:**
+```bash
+# List UTXOs from a frozenkrill wallet export
+cyberkrill list-utxos --wallet-file mywallet_pub.json
+
+# Create PSBT with wallet file (future enhancement)
+cyberkrill create-psbt --wallet-file mywallet_pub.json --outputs "bc1qaddr:0.001btc"
+
+# Move UTXOs using wallet file (future enhancement)
+cyberkrill move-utxos --wallet-file mywallet_pub.json --destination "bc1qconsolidated"
+```
+
+**Supported wallet types:**
+- Single-signature wallets (singlesig)
+- Multi-signature wallets (2-of-3, 3-of-5, etc.)
+
+**Benefits:**
+- No need to manually specify descriptors
+- Automatically includes both receiving and change addresses
+- Pre-validated addresses with derivation paths
+- Network and script type metadata included
 
 ## Amount Input Formats
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ cyberkrill create-psbt \
   --outputs "bc1qaddr:0.001btc" \
   --fee-rate 15sats
 
+# Using frozenkrill wallet file
+cyberkrill create-psbt \
+  --wallet-file mywallet_pub.json \
+  --inputs "txid1:0" --inputs "txid2:1" \
+  --outputs "bc1qaddr:0.001btc" \
+  --fee-rate 15sats
+
 # Mix specific UTXOs and descriptors
 cyberkrill create-psbt \
   --inputs "txid1:0" \
@@ -264,6 +271,12 @@ cyberkrill create-funded-psbt \
   --inputs "wpkh([fingerprint/84'/0'/0']xpub...)" \
   --outputs "bc1qaddr:0.001" \
   --fee-rate 20sats
+
+# Using frozenkrill wallet file for automatic input selection
+cyberkrill create-funded-psbt \
+  --wallet-file mywallet_pub.json \
+  --outputs "bc1qaddr:0.01btc" \
+  --fee-rate 10sats
 ```
 
 #### Consolidate UTXOs (Move UTXOs)
@@ -296,6 +309,13 @@ cyberkrill move-utxos \
   --inputs "wpkh([fingerprint/84'/0'/0']xpub...)" \
   --destination "bc1qconsolidated_address" \
   --fee-rate 20sats
+
+# Consolidate all UTXOs from a frozenkrill wallet
+cyberkrill move-utxos \
+  --wallet-file mywallet_pub.json \
+  --inputs "all" \
+  --destination "bc1qconsolidated_address" \
+  --fee-rate 15sats
 
 # Mix specific UTXOs and descriptors
 cyberkrill move-utxos \
@@ -411,11 +431,14 @@ CyberKrill supports frozenkrill wallet export files as an alternative to raw des
 # List UTXOs from a frozenkrill wallet export
 cyberkrill list-utxos --wallet-file mywallet_pub.json
 
-# Create PSBT with wallet file (future enhancement)
-cyberkrill create-psbt --wallet-file mywallet_pub.json --outputs "bc1qaddr:0.001btc"
+# Create PSBT with wallet file
+cyberkrill create-psbt --wallet-file mywallet_pub.json --outputs "bc1qaddr:0.001btc" --fee-rate 10sats
 
-# Move UTXOs using wallet file (future enhancement)
-cyberkrill move-utxos --wallet-file mywallet_pub.json --destination "bc1qconsolidated"
+# Create funded PSBT with wallet file
+cyberkrill create-funded-psbt --wallet-file mywallet_pub.json --outputs "bc1qaddr:0.001btc" --fee-rate 15sats
+
+# Move UTXOs using wallet file
+cyberkrill move-utxos --wallet-file mywallet_pub.json --destination "bc1qconsolidated" --fee-rate 20sats
 ```
 
 **Supported wallet types:**

--- a/cyberkrill-core/Cargo.toml
+++ b/cyberkrill-core/Cargo.toml
@@ -9,8 +9,9 @@ keywords = ["bitcoin", "lightning", "lnurl", "fedimint", "tapsigner"]
 categories = ["cryptography::cryptocurrencies"]
 
 [features]
-default = ["smartcards"]
+default = ["smartcards", "frozenkrill"]
 smartcards = ["cktap-direct", "rusb"]
+frozenkrill = ["frozenkrill-core"]
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }
@@ -36,3 +37,8 @@ sha2 = "0.10"
 bdk_wallet = "2.0.0"
 bdk_electrum = { version = "0.23.0", default-features = false, features = ["use-rustls"] }
 bdk_esplora = { version = "0.22.0", default-features = false, features = ["blocking", "blocking-https-rustls"] }
+# frozenkrill support
+frozenkrill-core = { git = "https://github.com/planktonlabs/frozenkrill", optional = true }
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/cyberkrill-core/src/bdk_wallet.rs
+++ b/cyberkrill-core/src/bdk_wallet.rs
@@ -512,15 +512,15 @@ pub async fn create_psbt_bdk(
     let utxos = if backend.starts_with("electrum://") {
         let url = backend.strip_prefix("electrum://").unwrap();
         use bdk_electrum::{electrum_client, BdkElectrumClient};
-        
+
         let client = BdkElectrumClient::new(
             electrum_client::Client::new(url).context("Failed to create Electrum client")?,
         );
-        
+
         let request = wallet.start_full_scan().build();
         let update = client.full_scan(request, 200, 10, false)?;
         wallet.apply_update(update)?;
-        
+
         // Now get the UTXOs from the synced wallet
         let wallet_utxos = wallet.list_unspent();
         let mut utxos = Vec::new();
@@ -528,7 +528,8 @@ pub async fn create_psbt_bdk(
             utxos.push(BdkUtxo {
                 txid: utxo.outpoint.txid.to_string(),
                 vout: utxo.outpoint.vout,
-                address: bitcoin::Address::from_script(&utxo.txout.script_pubkey, network)?.to_string(),
+                address: bitcoin::Address::from_script(&utxo.txout.script_pubkey, network)?
+                    .to_string(),
                 amount: utxo.txout.value.to_sat(),
                 amount_btc: utxo.txout.value.to_btc(),
                 confirmations: 0, // Not needed for this use case
@@ -536,7 +537,8 @@ pub async fn create_psbt_bdk(
                 keychain: match utxo.keychain {
                     KeychainKind::External => "external",
                     KeychainKind::Internal => "internal",
-                }.to_string(),
+                }
+                .to_string(),
                 derivation_index: None,
             });
         }
@@ -544,12 +546,12 @@ pub async fn create_psbt_bdk(
     } else if backend.starts_with("esplora://") {
         let url = backend.strip_prefix("esplora://").unwrap();
         use bdk_esplora::{esplora_client, EsploraExt};
-        
+
         let client = esplora_client::Builder::new(url).build_blocking();
         let request = wallet.start_full_scan().build();
         let update = client.full_scan(request, 200, 10)?;
         wallet.apply_update(update)?;
-        
+
         // Now get the UTXOs from the synced wallet
         let wallet_utxos = wallet.list_unspent();
         let mut utxos = Vec::new();
@@ -557,7 +559,8 @@ pub async fn create_psbt_bdk(
             utxos.push(BdkUtxo {
                 txid: utxo.outpoint.txid.to_string(),
                 vout: utxo.outpoint.vout,
-                address: bitcoin::Address::from_script(&utxo.txout.script_pubkey, network)?.to_string(),
+                address: bitcoin::Address::from_script(&utxo.txout.script_pubkey, network)?
+                    .to_string(),
                 amount: utxo.txout.value.to_sat(),
                 amount_btc: utxo.txout.value.to_btc(),
                 confirmations: 0, // Not needed for this use case
@@ -565,7 +568,8 @@ pub async fn create_psbt_bdk(
                 keychain: match utxo.keychain {
                     KeychainKind::External => "external",
                     KeychainKind::Internal => "internal",
-                }.to_string(),
+                }
+                .to_string(),
                 derivation_index: None,
             });
         }
@@ -674,18 +678,18 @@ pub async fn create_funded_psbt_bdk(
     if backend.starts_with("electrum://") {
         let url = backend.strip_prefix("electrum://").unwrap();
         use bdk_electrum::{electrum_client, BdkElectrumClient};
-        
+
         let client = BdkElectrumClient::new(
             electrum_client::Client::new(url).context("Failed to create Electrum client")?,
         );
-        
+
         let request = wallet.start_full_scan().build();
         let update = client.full_scan(request, 200, 10, false)?;
         wallet.apply_update(update)?;
     } else if backend.starts_with("esplora://") {
         let url = backend.strip_prefix("esplora://").unwrap();
         use bdk_esplora::{esplora_client, EsploraExt};
-        
+
         let client = esplora_client::Builder::new(url).build_blocking();
         let request = wallet.start_full_scan().build();
         let update = client.full_scan(request, 200, 10)?;
@@ -770,15 +774,15 @@ pub async fn move_utxos_bdk(
     let utxos = if backend.starts_with("electrum://") {
         let url = backend.strip_prefix("electrum://").unwrap();
         use bdk_electrum::{electrum_client, BdkElectrumClient};
-        
+
         let client = BdkElectrumClient::new(
             electrum_client::Client::new(url).context("Failed to create Electrum client")?,
         );
-        
+
         let request = wallet.start_full_scan().build();
         let update = client.full_scan(request, 200, 10, false)?;
         wallet.apply_update(update)?;
-        
+
         // Now get the UTXOs from the synced wallet
         let wallet_utxos = wallet.list_unspent();
         let mut utxos = Vec::new();
@@ -786,7 +790,8 @@ pub async fn move_utxos_bdk(
             utxos.push(BdkUtxo {
                 txid: utxo.outpoint.txid.to_string(),
                 vout: utxo.outpoint.vout,
-                address: bitcoin::Address::from_script(&utxo.txout.script_pubkey, network)?.to_string(),
+                address: bitcoin::Address::from_script(&utxo.txout.script_pubkey, network)?
+                    .to_string(),
                 amount: utxo.txout.value.to_sat(),
                 amount_btc: utxo.txout.value.to_btc(),
                 confirmations: 0, // Not needed for this use case
@@ -794,7 +799,8 @@ pub async fn move_utxos_bdk(
                 keychain: match utxo.keychain {
                     KeychainKind::External => "external",
                     KeychainKind::Internal => "internal",
-                }.to_string(),
+                }
+                .to_string(),
                 derivation_index: None,
             });
         }
@@ -802,12 +808,12 @@ pub async fn move_utxos_bdk(
     } else if backend.starts_with("esplora://") {
         let url = backend.strip_prefix("esplora://").unwrap();
         use bdk_esplora::{esplora_client, EsploraExt};
-        
+
         let client = esplora_client::Builder::new(url).build_blocking();
         let request = wallet.start_full_scan().build();
         let update = client.full_scan(request, 200, 10)?;
         wallet.apply_update(update)?;
-        
+
         // Now get the UTXOs from the synced wallet
         let wallet_utxos = wallet.list_unspent();
         let mut utxos = Vec::new();
@@ -815,7 +821,8 @@ pub async fn move_utxos_bdk(
             utxos.push(BdkUtxo {
                 txid: utxo.outpoint.txid.to_string(),
                 vout: utxo.outpoint.vout,
-                address: bitcoin::Address::from_script(&utxo.txout.script_pubkey, network)?.to_string(),
+                address: bitcoin::Address::from_script(&utxo.txout.script_pubkey, network)?
+                    .to_string(),
                 amount: utxo.txout.value.to_sat(),
                 amount_btc: utxo.txout.value.to_btc(),
                 confirmations: 0, // Not needed for this use case
@@ -823,7 +830,8 @@ pub async fn move_utxos_bdk(
                 keychain: match utxo.keychain {
                     KeychainKind::External => "external",
                     KeychainKind::Internal => "internal",
-                }.to_string(),
+                }
+                .to_string(),
                 derivation_index: None,
             });
         }

--- a/cyberkrill-core/src/bitcoin_rpc.rs
+++ b/cyberkrill-core/src/bitcoin_rpc.rs
@@ -42,7 +42,7 @@ pub enum AmountInputError {
 /// # Examples
 /// ```
 /// use std::str::FromStr;
-/// use cyberkrill::bitcoin_rpc::AmountInput;
+/// use cyberkrill_core::bitcoin_rpc::AmountInput;
 ///
 /// // Parse from different formats
 /// let amount1 = AmountInput::from_str("0.5")?;
@@ -69,11 +69,11 @@ impl AmountInput {
     ///
     /// # Examples
     /// ```
-    /// use cyberkrill::bitcoin_rpc::AmountInput;
+    /// use cyberkrill_core::bitcoin_rpc::AmountInput;
     ///
     /// let amount = AmountInput::from_btc(1.5)?;
     /// assert_eq!(amount.as_btc(), 1.5);
-    /// # Ok::<(), cyberkrill::bitcoin_rpc::AmountInputError>(())
+    /// # Ok::<(), cyberkrill_core::bitcoin_rpc::AmountInputError>(())
     /// ```
     ///
     /// # Errors
@@ -91,7 +91,7 @@ impl AmountInput {
     ///
     /// # Examples
     /// ```
-    /// use cyberkrill::bitcoin_rpc::AmountInput;
+    /// use cyberkrill_core::bitcoin_rpc::AmountInput;
     ///
     /// let amount = AmountInput::from_sats(150000000);
     /// assert_eq!(amount.as_sat(), 150000000);
@@ -107,11 +107,12 @@ impl AmountInput {
     ///
     /// # Examples
     /// ```
-    /// use cyberkrill::bitcoin_rpc::AmountInput;
+    /// use cyberkrill_core::bitcoin_rpc::AmountInput;
     ///
-    /// let amount = AmountInput::from_fractional_sats(1.5);
+    /// let amount = AmountInput::from_fractional_sats(1.5)?;
     /// assert_eq!(amount.as_millisats(), 1500);
     /// assert_eq!(amount.as_sat(), 1); // Rounds down to whole satoshis
+    /// # Ok::<(), cyberkrill_core::bitcoin_rpc::AmountInputError>(())
     /// ```
     pub fn from_fractional_sats(sats: f64) -> Result<Self, AmountInputError> {
         if sats < 0.0 {
@@ -126,7 +127,7 @@ impl AmountInput {
     ///
     /// # Examples
     /// ```
-    /// use cyberkrill::bitcoin_rpc::AmountInput;
+    /// use cyberkrill_core::bitcoin_rpc::AmountInput;
     ///
     /// let amount = AmountInput::from_millisats(1500);
     /// assert_eq!(amount.as_millisats(), 1500);
@@ -140,7 +141,7 @@ impl AmountInput {
     ///
     /// # Examples
     /// ```
-    /// use cyberkrill::bitcoin_rpc::AmountInput;
+    /// use cyberkrill_core::bitcoin_rpc::AmountInput;
     ///
     /// let amount = AmountInput::from_sats(100000000);
     /// assert_eq!(amount.as_sat(), 100000000);
@@ -156,7 +157,7 @@ impl AmountInput {
     ///
     /// # Examples
     /// ```
-    /// use cyberkrill::bitcoin_rpc::AmountInput;
+    /// use cyberkrill_core::bitcoin_rpc::AmountInput;
     ///
     /// let amount = AmountInput::from_sats(100000000);
     /// assert_eq!(amount.as_btc(), 1.0);
@@ -169,11 +170,11 @@ impl AmountInput {
     ///
     /// # Examples
     /// ```
-    /// use cyberkrill::bitcoin_rpc::AmountInput;
+    /// use cyberkrill_core::bitcoin_rpc::AmountInput;
     ///
     /// let amount = AmountInput::from_fractional_sats(1.5)?;
     /// assert_eq!(amount.as_millisats(), 1500);
-    /// # Ok::<(), cyberkrill::bitcoin_rpc::AmountInputError>(())
+    /// # Ok::<(), cyberkrill_core::bitcoin_rpc::AmountInputError>(())
     /// ```
     pub fn as_millisats(&self) -> u64 {
         self.millisats
@@ -183,7 +184,7 @@ impl AmountInput {
     ///
     /// # Examples
     /// ```
-    /// use cyberkrill::bitcoin_rpc::AmountInput;
+    /// use cyberkrill_core::bitcoin_rpc::AmountInput;
     ///
     /// let amount = AmountInput::from_millisats(1500);
     /// assert_eq!(amount.as_fractional_sats(), 1.5);
@@ -200,7 +201,7 @@ impl AmountInput {
     ///
     /// # Examples
     /// ```
-    /// use cyberkrill::bitcoin_rpc::AmountInput;
+    /// use cyberkrill_core::bitcoin_rpc::AmountInput;
     /// use bitcoin::Amount;
     ///
     /// let amount_input = AmountInput::from_sats(100000000);
@@ -589,6 +590,44 @@ impl BitcoinRpcClient {
             .sum();
         let total_count = utxos.len();
         let utxo_outputs: Vec<UtxoOutput> = utxos.into_iter().map(Into::into).collect();
+
+        Ok(UtxoListResponse {
+            utxos: utxo_outputs,
+            total_amount_sats,
+            total_count,
+        })
+    }
+
+    /// List UTXOs from a frozenkrill wallet export file
+    #[cfg(feature = "frozenkrill")]
+    pub async fn list_utxos_from_wallet_file(
+        &self,
+        wallet_path: &Path,
+    ) -> Result<UtxoListResponse> {
+        use crate::frozenkrill::FrozenkrillWallet;
+
+        let wallet = FrozenkrillWallet::from_file(wallet_path)
+            .with_context(|| format!("Failed to load wallet from {}", wallet_path.display()))?;
+
+        // List UTXOs for both receiving and change descriptors
+        let receiving_utxos = self
+            .list_unspent_for_descriptor(wallet.receiving_descriptor())
+            .await?;
+        let change_utxos = self
+            .list_unspent_for_descriptor(wallet.change_descriptor())
+            .await?;
+
+        // Combine all UTXOs
+        let mut all_utxos = receiving_utxos;
+        all_utxos.extend(change_utxos);
+
+        // Calculate totals
+        let total_amount_sats: u64 = all_utxos
+            .iter()
+            .map(|u| Amount::from_btc(u.amount).unwrap_or(Amount::ZERO).to_sat())
+            .sum();
+        let total_count = all_utxos.len();
+        let utxo_outputs: Vec<UtxoOutput> = all_utxos.into_iter().map(Into::into).collect();
 
         Ok(UtxoListResponse {
             utxos: utxo_outputs,

--- a/cyberkrill-core/src/bitcoin_rpc.rs
+++ b/cyberkrill-core/src/bitcoin_rpc.rs
@@ -636,6 +636,20 @@ impl BitcoinRpcClient {
         })
     }
 
+    /// Get descriptors from a frozenkrill wallet export file
+    #[cfg(feature = "frozenkrill")]
+    pub fn get_descriptors_from_wallet_file(wallet_path: &Path) -> Result<(String, String)> {
+        use crate::frozenkrill::FrozenkrillWallet;
+
+        let wallet = FrozenkrillWallet::from_file(wallet_path)
+            .with_context(|| format!("Failed to load wallet from {}", wallet_path.display()))?;
+
+        Ok((
+            wallet.receiving_descriptor().to_string(),
+            wallet.change_descriptor().to_string(),
+        ))
+    }
+
     async fn get_current_block_height(&self) -> Result<u64> {
         let result = self
             .rpc_call("getblockchaininfo", serde_json::json!([]))

--- a/cyberkrill-core/src/frozenkrill.rs
+++ b/cyberkrill-core/src/frozenkrill.rs
@@ -1,0 +1,392 @@
+use anyhow::{Context, Result};
+use bitcoin::Network;
+use serde::Deserialize;
+use std::io::BufReader;
+use std::path::Path;
+
+use frozenkrill_core::wallet_export::GenericOutputExportJson;
+
+// Re-define the structures with public fields to work around private field access
+#[derive(Debug, Deserialize)]
+struct SingleSigWalletData {
+    #[allow(dead_code)]
+    wallet: String,
+    #[allow(dead_code)]
+    version: u32,
+    #[allow(dead_code)]
+    sigtype: String,
+    #[allow(dead_code)]
+    master_fingerprint: String,
+    #[allow(dead_code)]
+    singlesig_xpub: String,
+    #[allow(dead_code)]
+    singlesig_derivation_path: String,
+    #[allow(dead_code)]
+    multisig_xpub: String,
+    #[allow(dead_code)]
+    multisig_derivation_path: String,
+    singlesig_receiving_output_descriptor: String,
+    singlesig_change_output_descriptor: String,
+    #[allow(dead_code)]
+    multisig_receiving_output_descriptor_key: String,
+    #[allow(dead_code)]
+    multisig_change_output_descriptor_key: String,
+    #[allow(dead_code)]
+    script_type: String,
+    network: String,
+    receiving_addresses: Vec<AddressInfo>,
+    change_addresses: Vec<AddressInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MultiSigWalletData {
+    #[allow(dead_code)]
+    wallet: String,
+    #[allow(dead_code)]
+    version: u32,
+    sigtype: String,
+    #[allow(dead_code)]
+    script_type: String,
+    network: String,
+    receiving_output_descriptor: String,
+    change_output_descriptor: String,
+    receiving_addresses: Vec<AddressInfo>,
+    change_addresses: Vec<AddressInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AddressInfo {
+    address: String,
+    #[allow(dead_code)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    derivation_path: Option<String>,
+    #[allow(dead_code)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<u32>,
+}
+
+/// Represents a frozenkrill wallet export, either single-sig or multi-sig
+#[derive(Debug)]
+#[allow(private_interfaces)]
+pub enum FrozenkrillWallet {
+    #[doc(hidden)]
+    SingleSig(SingleSigWalletData),
+    #[doc(hidden)]
+    MultiSig(MultiSigWalletData),
+}
+
+impl FrozenkrillWallet {
+    /// Load a frozenkrill wallet from a JSON export file
+    pub fn from_file(path: &Path) -> Result<Self> {
+        // First pass: detect wallet type
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("Failed to open wallet file: {}", path.display()))?;
+        let reader = BufReader::new(file);
+
+        let generic = GenericOutputExportJson::deserialize(reader)?;
+        let (_version, sigtype) = generic.version_sigtype()?;
+
+        // Second pass: deserialize with our own structures
+        let content = std::fs::read_to_string(path)?;
+
+        match sigtype {
+            Some(frozenkrill_core::wallet_description::SigType::Singlesig) => {
+                let wallet: SingleSigWalletData = serde_json::from_str(&content)?;
+                Ok(Self::SingleSig(wallet))
+            }
+            Some(frozenkrill_core::wallet_description::SigType::Multisig(_)) => {
+                let wallet: MultiSigWalletData = serde_json::from_str(&content)?;
+                Ok(Self::MultiSig(wallet))
+            }
+            _ => anyhow::bail!("Unknown or missing wallet signature type"),
+        }
+    }
+
+    /// Get the receiving (external) descriptor
+    pub fn receiving_descriptor(&self) -> &str {
+        match self {
+            Self::SingleSig(s) => &s.singlesig_receiving_output_descriptor,
+            Self::MultiSig(m) => &m.receiving_output_descriptor,
+        }
+    }
+
+    /// Get the change (internal) descriptor
+    pub fn change_descriptor(&self) -> &str {
+        match self {
+            Self::SingleSig(s) => &s.singlesig_change_output_descriptor,
+            Self::MultiSig(m) => &m.change_output_descriptor,
+        }
+    }
+
+    /// Get the Bitcoin network this wallet is for
+    pub fn network(&self) -> Network {
+        let network_str = match self {
+            Self::SingleSig(s) => &s.network,
+            Self::MultiSig(m) => &m.network,
+        };
+
+        match network_str.as_str() {
+            "bitcoin" => Network::Bitcoin,
+            "testnet" => Network::Testnet,
+            "regtest" => Network::Regtest,
+            "signet" => Network::Signet,
+            _ => Network::Bitcoin, // Default to mainnet
+        }
+    }
+
+    /// Check if an address belongs to this wallet
+    pub fn contains_address(&self, address: &str) -> bool {
+        match self {
+            Self::SingleSig(s) => {
+                s.receiving_addresses.iter().any(|a| a.address == address)
+                    || s.change_addresses.iter().any(|a| a.address == address)
+            }
+            Self::MultiSig(m) => {
+                m.receiving_addresses.iter().any(|a| a.address == address)
+                    || m.change_addresses.iter().any(|a| a.address == address)
+            }
+        }
+    }
+
+    /// Check if an address is a change address
+    /// Returns Some(true) if it's a change address, Some(false) if it's a receiving address,
+    /// or None if the address is not found in the wallet
+    pub fn is_change_address(&self, address: &str) -> Option<bool> {
+        match self {
+            Self::SingleSig(s) => {
+                if s.receiving_addresses.iter().any(|a| a.address == address) {
+                    Some(false)
+                } else if s.change_addresses.iter().any(|a| a.address == address) {
+                    Some(true)
+                } else {
+                    None
+                }
+            }
+            Self::MultiSig(m) => {
+                if m.receiving_addresses.iter().any(|a| a.address == address) {
+                    Some(false)
+                } else if m.change_addresses.iter().any(|a| a.address == address) {
+                    Some(true)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// Get all receiving addresses
+    pub fn receiving_addresses(&self) -> Vec<&str> {
+        match self {
+            Self::SingleSig(s) => s
+                .receiving_addresses
+                .iter()
+                .map(|a| a.address.as_str())
+                .collect(),
+            Self::MultiSig(m) => m
+                .receiving_addresses
+                .iter()
+                .map(|a| a.address.as_str())
+                .collect(),
+        }
+    }
+
+    /// Get all change addresses
+    pub fn change_addresses(&self) -> Vec<&str> {
+        match self {
+            Self::SingleSig(s) => s
+                .change_addresses
+                .iter()
+                .map(|a| a.address.as_str())
+                .collect(),
+            Self::MultiSig(m) => m
+                .change_addresses
+                .iter()
+                .map(|a| a.address.as_str())
+                .collect(),
+        }
+    }
+
+    /// Get the master fingerprint for single-sig wallets
+    pub fn master_fingerprint(&self) -> Option<&str> {
+        match self {
+            Self::SingleSig(s) => Some(&s.master_fingerprint),
+            Self::MultiSig(_) => None,
+        }
+    }
+
+    /// Get the wallet type as a string
+    pub fn wallet_type(&self) -> &str {
+        match self {
+            Self::SingleSig(s) => &s.sigtype,
+            Self::MultiSig(m) => &m.sigtype,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn create_test_singlesig_wallet() -> String {
+        r#"{
+  "wallet": "frozenkrill",
+  "version": 0,
+  "sigtype": "singlesig",
+  "master_fingerprint": "84577e03",
+  "singlesig_xpub": "zpub6rerbAfYxT86ZiHXkVYcJJLMFZzy5MF1gLmjuDFNxwN3NPZEC5PesEhzm5AYY7TJixkEAeFrNFRWEyRKLN9jLtNLeZkk2YchzaPkyL7eXqw",
+  "singlesig_derivation_path": "84'/0'/0'",
+  "multisig_xpub": "Zpub75EVv3vodU4dLT8VaR4eworLZJY1gnKyE1thSST7oQNMvPheFPLNfZhj9em55PyMtcju8A3DzTP3n8HCwgK7JbLJ6KKZf22f4Lw9ouMS2C2",
+  "multisig_derivation_path": "48'/0'/0'/2'",
+  "singlesig_receiving_output_descriptor": "wpkh([84577e03/84'/0'/0']xpub6CzKyqKif638s7uJ5myMt89Ludi5C7G1r7jJLRTcCvcHGBvmgm4Xd7PiifFNYJ9TugWcfh4jSviQUQCBtyKhkR18utMtriyjT8GUCAqCaC7/0/*)#x703tmpk",
+  "singlesig_change_output_descriptor": "wpkh([84577e03/84'/0'/0']xpub6CzKyqKif638s7uJ5myMt89Ludi5C7G1r7jJLRTcCvcHGBvmgm4Xd7PiifFNYJ9TugWcfh4jSviQUQCBtyKhkR18utMtriyjT8GUCAqCaC7/1/*)#h22skw3w",
+  "multisig_receiving_output_descriptor_key": "[84577e03/48'/0'/0'/2']xpub6DqBpAififEzKdbFYBcTXZRWebb8b5TbLRnQwqCbnX5bAqPXPxvBMEaQ8vSYdaeGvxvQdQCN3cz78Q4wJkY1LMAcXHK4zXACrMGC8VJx3rZ/0/*",
+  "multisig_change_output_descriptor_key": "[84577e03/48'/0'/0'/2']xpub6DqBpAififEzKdbFYBcTXZRWebb8b5TbLRnQwqCbnX5bAqPXPxvBMEaQ8vSYdaeGvxvQdQCN3cz78Q4wJkY1LMAcXHK4zXACrMGC8VJx3rZ/1/*",
+  "script_type": "segwit-native",
+  "network": "bitcoin",
+  "receiving_addresses": [
+    {
+      "address": "bc1qtm70qpd2h0v7kyaga72tq2nnmmjj5zcjerqq0c",
+      "derivation_path": "84'/0'/0'/0/0"
+    },
+    {
+      "address": "bc1q5q8wrzt3w2safvegkmml3lz0avvfrevn4udmx9",
+      "derivation_path": "84'/0'/0'/0/1"
+    }
+  ],
+  "change_addresses": [
+    {
+      "address": "bc1qs0kf5pf8ftfu2pzyd70sl9vl3885459znalqy2",
+      "derivation_path": "84'/0'/0'/1/0"
+    },
+    {
+      "address": "bc1qp2ejr88vsschtnyvcdqkxmwutlqzepw6r7vfzg",
+      "derivation_path": "84'/0'/0'/1/1"
+    }
+  ]
+}"#
+        .to_string()
+    }
+
+    fn create_test_multisig_wallet() -> String {
+        r#"{
+  "wallet": "frozenkrill",
+  "version": 0,
+  "sigtype": "2-of-3",
+  "script_type": "segwit-native",
+  "network": "bitcoin",
+  "receiving_output_descriptor": "wsh(sortedmulti(2,[1c2b4725/48'/0'/0'/2']xpub6Dp8hC2nCxMi8E8LwP8Wd2KzTnoe7PE8eRXt411uwvNqvwxYCGRiAxZvu4GRQQmXisb5PvUmERsehSPCU7SJAJDYri3BB3q9YzymHs4idPS/0/*,[88c3e90a/48'/0'/0'/2']xpub6DrbCDR2BEyrc9yFqvwb1rUPamk9ULmn9RSFBykKxWu3Ryh7bYoFAM9vhGiZ7fgVSSu2MB4UzUGvkreuVuH19rwAcZ4skxVb9R5PzXn1dMu/0/*,[a0342720/48'/0'/0'/2']xpub6Er6q7NDEyU4Z4KRZFMqh5R5vWbQXhnL4PhCpkXMW1CVq4N7VdccEX2RoTuAZXTmVqaTirR4JcmnDkEASVwetHZkisiqmhjmKBUd6KndpcC/0/*))#vcntmeq2",
+  "change_output_descriptor": "wsh(sortedmulti(2,[1c2b4725/48'/0'/0'/2']xpub6Dp8hC2nCxMi8E8LwP8Wd2KzTnoe7PE8eRXt411uwvNqvwxYCGRiAxZvu4GRQQmXisb5PvUmERsehSPCU7SJAJDYri3BB3q9YzymHs4idPS/1/*,[88c3e90a/48'/0'/0'/2']xpub6DrbCDR2BEyrc9yFqvwb1rUPamk9ULmn9RSFBykKxWu3Ryh7bYoFAM9vhGiZ7fgVSSu2MB4UzUGvkreuVuH19rwAcZ4skxVb9R5PzXn1dMu/1/*,[a0342720/48'/0'/0'/2']xpub6Er6q7NDEyU4Z4KRZFMqh5R5vWbQXhnL4PhCpkXMW1CVq4N7VdccEX2RoTuAZXTmVqaTirR4JcmnDkEASVwetHZkisiqmhjmKBUd6KndpcC/1/*))#fdc39lsz",
+  "receiving_addresses": [
+    {
+      "address": "bc1q9h4r8pk4p6ufsaaqpk5w09h7fr983nf9pcef6vfqcujawge2m3ssaqs7dp",
+      "index": 0
+    },
+    {
+      "address": "bc1qm78ddhzndtlqzc0fszr7kj3fvvj7xwu9uhdqfzxu4n4eklwevwqqqgg8at",
+      "index": 1
+    }
+  ],
+  "change_addresses": [
+    {
+      "address": "bc1ql9jt3v4q4f0shyqw0dzjw3hflq04xskqf26mqj6p7t3dga7j4y9sq9nz6g",
+      "index": 0
+    },
+    {
+      "address": "bc1qnzfp4sjypfyq3fcamjszrvwgqyg3gzjufk4w2qvw3u0vj2pz5zns2gaj5r",
+      "index": 1
+    }
+  ]
+}"#
+        .to_string()
+    }
+
+    #[test]
+    fn test_load_singlesig_wallet() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(create_test_singlesig_wallet().as_bytes())?;
+
+        let wallet = FrozenkrillWallet::from_file(temp_file.path())?;
+
+        match &wallet {
+            FrozenkrillWallet::SingleSig(s) => {
+                assert_eq!(s.master_fingerprint, "84577e03");
+                assert_eq!(s.network, "bitcoin");
+                assert_eq!(s.sigtype, "singlesig");
+                assert_eq!(s.receiving_addresses.len(), 2);
+                assert_eq!(s.change_addresses.len(), 2);
+            }
+            _ => panic!("Expected SingleSig wallet"),
+        }
+
+        assert_eq!(wallet.network(), Network::Bitcoin);
+        assert_eq!(wallet.wallet_type(), "singlesig");
+        assert!(wallet.contains_address("bc1qtm70qpd2h0v7kyaga72tq2nnmmjj5zcjerqq0c"));
+        assert_eq!(
+            wallet.is_change_address("bc1qtm70qpd2h0v7kyaga72tq2nnmmjj5zcjerqq0c"),
+            Some(false)
+        );
+        assert_eq!(
+            wallet.is_change_address("bc1qs0kf5pf8ftfu2pzyd70sl9vl3885459znalqy2"),
+            Some(true)
+        );
+        assert_eq!(wallet.is_change_address("bc1qinvalid"), None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_load_multisig_wallet() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(create_test_multisig_wallet().as_bytes())?;
+
+        let wallet = FrozenkrillWallet::from_file(temp_file.path())?;
+
+        match &wallet {
+            FrozenkrillWallet::MultiSig(m) => {
+                assert_eq!(m.network, "bitcoin");
+                assert_eq!(m.sigtype, "2-of-3");
+                assert_eq!(m.receiving_addresses.len(), 2);
+                assert_eq!(m.change_addresses.len(), 2);
+            }
+            _ => panic!("Expected MultiSig wallet"),
+        }
+
+        assert_eq!(wallet.network(), Network::Bitcoin);
+        assert_eq!(wallet.wallet_type(), "2-of-3");
+        assert!(wallet
+            .contains_address("bc1q9h4r8pk4p6ufsaaqpk5w09h7fr983nf9pcef6vfqcujawge2m3ssaqs7dp"));
+        assert_eq!(wallet.master_fingerprint(), None); // No fingerprint for multisig
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_invalid_wallet_file() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(b"invalid json").unwrap();
+
+        let result = FrozenkrillWallet::from_file(temp_file.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wallet_descriptors() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(create_test_singlesig_wallet().as_bytes())?;
+
+        let wallet = FrozenkrillWallet::from_file(temp_file.path())?;
+
+        assert!(wallet
+            .receiving_descriptor()
+            .starts_with("wpkh([84577e03/84'/0'/0']"));
+        assert!(wallet
+            .change_descriptor()
+            .starts_with("wpkh([84577e03/84'/0'/0']"));
+        assert!(wallet.receiving_descriptor().ends_with("/0/*)#x703tmpk"));
+        assert!(wallet.change_descriptor().ends_with("/1/*)#h22skw3w"));
+
+        Ok(())
+    }
+}

--- a/cyberkrill-core/src/lib.rs
+++ b/cyberkrill-core/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod bdk_wallet;
 pub mod bitcoin_rpc;
 pub mod decoder;
+#[cfg(feature = "frozenkrill")]
+pub mod frozenkrill;
 #[cfg(feature = "smartcards")]
 pub mod satscard;
 #[cfg(feature = "smartcards")]
@@ -32,3 +34,7 @@ pub use bitcoin::{self, Network};
 
 // Re-export fedimint functionality
 pub use fedimint_lite;
+
+// Re-export frozenkrill functionality
+#[cfg(feature = "frozenkrill")]
+pub use frozenkrill::FrozenkrillWallet;

--- a/cyberkrill/Cargo.toml
+++ b/cyberkrill/Cargo.toml
@@ -7,8 +7,9 @@ license = "MIT"
 repository = "https://github.com/douglaz/cyberkrill"
 
 [features]
-default = ["smartcards"]
+default = ["smartcards", "frozenkrill"]
 smartcards = ["cyberkrill-core/smartcards"]
+frozenkrill = ["cyberkrill-core/frozenkrill"]
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }

--- a/cyberkrill/src/main.rs
+++ b/cyberkrill/src/main.rs
@@ -215,8 +215,13 @@ struct ListUtxosArgs {
 
 #[derive(clap::Args, Debug)]
 struct CreatePsbtArgs {
+    /// frozenkrill wallet export file to use for address derivation
+    #[cfg(feature = "frozenkrill")]
+    #[clap(long, conflicts_with = "descriptor")]
+    wallet_file: Option<std::path::PathBuf>,
     /// Output descriptor (required when using BDK backends)
-    #[clap(long)]
+    #[cfg_attr(feature = "frozenkrill", clap(long, conflicts_with = "wallet_file"))]
+    #[cfg_attr(not(feature = "frozenkrill"), clap(long))]
     descriptor: Option<String>,
 
     // Backend selection options (mutually exclusive)
@@ -264,8 +269,13 @@ struct CreatePsbtArgs {
 
 #[derive(clap::Args, Debug)]
 struct CreateFundedPsbtArgs {
+    /// frozenkrill wallet export file to use for address derivation
+    #[cfg(feature = "frozenkrill")]
+    #[clap(long, conflicts_with = "descriptor")]
+    wallet_file: Option<std::path::PathBuf>,
     /// Output descriptor (required when using BDK backends)
-    #[clap(long)]
+    #[cfg_attr(feature = "frozenkrill", clap(long, conflicts_with = "wallet_file"))]
+    #[cfg_attr(not(feature = "frozenkrill"), clap(long))]
     descriptor: Option<String>,
 
     // Backend selection options (mutually exclusive)
@@ -320,8 +330,13 @@ struct CreateFundedPsbtArgs {
 
 #[derive(clap::Args, Debug)]
 struct MoveUtxosArgs {
+    /// frozenkrill wallet export file to use for UTXO discovery
+    #[cfg(feature = "frozenkrill")]
+    #[clap(long, conflicts_with = "descriptor")]
+    wallet_file: Option<std::path::PathBuf>,
     /// Output descriptor (required when using BDK backends)
-    #[clap(long)]
+    #[cfg_attr(feature = "frozenkrill", clap(long, conflicts_with = "wallet_file"))]
+    #[cfg_attr(not(feature = "frozenkrill"), clap(long))]
     descriptor: Option<String>,
 
     // Backend selection options (mutually exclusive)
@@ -656,15 +671,27 @@ async fn bitcoin_create_psbt(args: CreatePsbtArgs) -> anyhow::Result<()> {
         ),
     };
 
+    // Get descriptor from wallet file or direct input
+    #[cfg(feature = "frozenkrill")]
+    let descriptor = if let Some(wallet_file) = &args.wallet_file {
+        let (receiving_desc, _change_desc) =
+            cyberkrill_core::BitcoinRpcClient::get_descriptors_from_wallet_file(wallet_file)?;
+        Some(receiving_desc)
+    } else {
+        args.descriptor.clone()
+    };
+    #[cfg(not(feature = "frozenkrill"))]
+    let descriptor = args.descriptor.clone();
+
     // Check if we're using BDK backends
     if args.electrum.is_some()
         || args.esplora.is_some()
-        || (args.descriptor.is_some() && args.bitcoin_dir.is_some())
+        || (descriptor.is_some() && args.bitcoin_dir.is_some())
     {
         // BDK path: require descriptor
-        let descriptor = args
-            .descriptor
-            .ok_or_else(|| anyhow::anyhow!("--descriptor is required when using BDK backends"))?;
+        let descriptor = descriptor.ok_or_else(|| {
+            anyhow::anyhow!("--descriptor or --wallet-file is required when using BDK backends")
+        })?;
 
         // Parse outputs
         let outputs = parse_outputs(&args.outputs)?;
@@ -745,15 +772,27 @@ async fn bitcoin_create_funded_psbt(args: CreateFundedPsbtArgs) -> anyhow::Resul
         ),
     };
 
+    // Get descriptor from wallet file or direct input
+    #[cfg(feature = "frozenkrill")]
+    let descriptor = if let Some(wallet_file) = &args.wallet_file {
+        let (receiving_desc, _change_desc) =
+            cyberkrill_core::BitcoinRpcClient::get_descriptors_from_wallet_file(wallet_file)?;
+        Some(receiving_desc)
+    } else {
+        args.descriptor.clone()
+    };
+    #[cfg(not(feature = "frozenkrill"))]
+    let descriptor = args.descriptor.clone();
+
     // Check if we're using BDK backends
     if args.electrum.is_some()
         || args.esplora.is_some()
-        || (args.descriptor.is_some() && args.bitcoin_dir.is_some())
+        || (descriptor.is_some() && args.bitcoin_dir.is_some())
     {
         // BDK path: require descriptor
-        let descriptor = args
-            .descriptor
-            .ok_or_else(|| anyhow::anyhow!("--descriptor is required when using BDK backends"))?;
+        let descriptor = descriptor.ok_or_else(|| {
+            anyhow::anyhow!("--descriptor or --wallet-file is required when using BDK backends")
+        })?;
 
         // Parse outputs
         let outputs = parse_outputs(&args.outputs)?;
@@ -859,15 +898,27 @@ async fn bitcoin_move_utxos(args: MoveUtxosArgs) -> anyhow::Result<()> {
         ),
     };
 
+    // Get descriptor from wallet file or direct input
+    #[cfg(feature = "frozenkrill")]
+    let descriptor = if let Some(wallet_file) = &args.wallet_file {
+        let (receiving_desc, _change_desc) =
+            cyberkrill_core::BitcoinRpcClient::get_descriptors_from_wallet_file(wallet_file)?;
+        Some(receiving_desc)
+    } else {
+        args.descriptor.clone()
+    };
+    #[cfg(not(feature = "frozenkrill"))]
+    let descriptor = args.descriptor.clone();
+
     // Check if we're using BDK backends
     if args.electrum.is_some()
         || args.esplora.is_some()
-        || (args.descriptor.is_some() && args.bitcoin_dir.is_some())
+        || (descriptor.is_some() && args.bitcoin_dir.is_some())
     {
         // BDK path: require descriptor
-        let descriptor = args
-            .descriptor
-            .ok_or_else(|| anyhow::anyhow!("--descriptor is required when using BDK backends"))?;
+        let descriptor = descriptor.ok_or_else(|| {
+            anyhow::anyhow!("--descriptor or --wallet-file is required when using BDK backends")
+        })?;
 
         // Convert fee rate if provided
         let fee_rate_sat_vb = args.fee_rate.map(|rate| {

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,8 @@
             lockFile = ./Cargo.lock;
             outputHashes = {
               "cktap-direct-0.1.0" = "sha256-ddQhghrmtwXKr750bTzjolSDLwyNZFUskNhJrR2vyBo=";
+              "bip39-2.2.0" = "sha256-gtUvFo0A8mPdBfqp5jwMzS/tpNc1YRHWliIc27FYioA=";
+              "frozenkrill-core-0.0.0" = "sha256-awlbxP38IvzRRMorKa/tZNY9cXJ3EokAIkt/9J2MuRs=";
             };
           };
           
@@ -97,6 +99,8 @@
             lockFile = ./Cargo.lock;
             outputHashes = {
               "cktap-direct-0.1.0" = "sha256-ddQhghrmtwXKr750bTzjolSDLwyNZFUskNhJrR2vyBo=";
+              "bip39-2.2.0" = "sha256-gtUvFo0A8mPdBfqp5jwMzS/tpNc1YRHWliIc27FYioA=";
+              "frozenkrill-core-0.0.0" = "sha256-awlbxP38IvzRRMorKa/tZNY9cXJ3EokAIkt/9J2MuRs=";
             };
           };
           


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for frozenkrill wallet export JSON files as an alternative to raw descriptors across all CyberKrill Bitcoin commands.

## Changes
- Added `frozenkrill-core` dependency from GitHub repository
- Created `frozenkrill.rs` wrapper module to handle private field access limitations
- Implemented wallet loading for both single-sig and multi-sig wallet types
- Added `--wallet-file` option to ALL commands that accept descriptors:
  - `list-utxos` (initial implementation)
  - `create-psbt` (NEW)
  - `create-funded-psbt` (NEW)
  - `move-utxos` (NEW)
- Added helper method `get_descriptors_from_wallet_file()` for consistent descriptor extraction
- Updated all command handlers to support wallet files
- Comprehensive test coverage for wallet functionality
- Updated README.md with usage examples for all commands

## Technical Details
The implementation uses a wrapper approach to work around private fields in the frozenkrill-core crate. We define our own structures that mirror the JSON format and use the frozenkrill-core library only for wallet type detection.

### Supported Features:
- ✅ Single-signature wallet exports
- ✅ Multi-signature wallet exports (2-of-3, 3-of-5, etc.)
- ✅ Automatic descriptor extraction (receiving and change)
- ✅ Address validation and verification
- ✅ Network detection and validation
- ✅ Works with all backends: Bitcoin Core RPC, Electrum, Esplora

## Test Plan
- [x] Reviewed code against CONVENTIONS.md
- [x] cargo fmt - code formatted
- [x] cargo clippy - no warnings
- [x] cargo test - all tests pass
- [x] Manual testing completed
- [x] Unit tests pass for single-sig wallet loading
- [x] Unit tests pass for multi-sig wallet loading
- [x] Error handling tests for invalid files
- [x] Integration with all Bitcoin commands

## Example Usage
```bash
# List UTXOs from a frozenkrill wallet
cyberkrill list-utxos --wallet-file mywallet_pub.json

# Create PSBT with wallet file
cyberkrill create-psbt --wallet-file mywallet_pub.json \
  --inputs "txid:0" --outputs "bc1qaddr:0.001btc" --fee-rate 10sats

# Create funded PSBT (automatic input selection)
cyberkrill create-funded-psbt --wallet-file mywallet_pub.json \
  --outputs "bc1qaddr:0.01btc" --fee-rate 15sats

# Consolidate all UTXOs from wallet
cyberkrill move-utxos --wallet-file mywallet_pub.json \
  --inputs "all" --destination "bc1qconsolidated" --fee-rate 20sats

# Works with all backends
cyberkrill list-utxos --wallet-file wallet.json --electrum ssl://electrum.blockstream.info:50002
cyberkrill create-psbt --wallet-file wallet.json --esplora https://blockstream.info/api ...
```

## Benefits
- **User-friendly**: No need to manually copy/paste descriptors
- **Consistent**: Same `--wallet-file` option works across all commands
- **Safe**: Pre-validated addresses with metadata
- **Flexible**: Works with existing descriptor-based workflows too

## Breaking Changes
None - this is a purely additive feature. All existing command usage remains unchanged.

## Implementation Notes
The type is named `FrozenkrillWallet` to match the crate name (lowercase "frozenkrill") while maintaining Rust naming conventions for types.