### PR TITLE
feat: add async Jade hardware wallet support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -347,7 +347,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -447,6 +447,12 @@ dependencies = [
  "hex-conservative 0.2.1",
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -551,7 +557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 2.6.0",
 ]
 
 [[package]]
@@ -670,6 +676,32 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
@@ -792,9 +824,10 @@ dependencies = [
  "fedimint-lite",
  "frozenkrill-core",
  "hex",
+ "jade-bitcoin",
  "lightning-invoice",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.22",
  "rusb",
  "secp256k1",
  "serde",
@@ -920,6 +953,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +982,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -974,7 +1039,7 @@ dependencies = [
  "anyhow",
  "bech32 0.9.1",
  "hex",
- "reqwest",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "tokio",
@@ -1038,7 +1103,7 @@ dependencies = [
  "bip39",
  "bitcoin",
  "blake3",
- "env_logger",
+ "env_logger 0.10.2",
  "flate2",
  "hex",
  "itertools 0.13.0",
@@ -1067,12 +1132,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1080,6 +1161,40 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -1093,10 +1208,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1159,6 +1280,31 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -1269,6 +1415,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -1280,12 +1437,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1296,8 +1464,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1308,10 +1476,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1322,8 +1520,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1334,17 +1532,31 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.29",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower-service",
  "webpki-roots 1.0.2",
 ]
@@ -1360,9 +1572,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1500,12 +1712,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "libc",
 ]
@@ -1566,6 +1788,49 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jade-bitcoin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitcoin",
+ "env_logger 0.11.8",
+ "hex",
+ "log",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-serial",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1650,7 +1915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1659,7 +1924,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -1755,10 +2020,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1814,8 +2094,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "mio-serial"
+version = "5.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029e1f407e261176a983a6599c084efd322d9301028055c87174beac71397ba3"
+dependencies = [
+ "log",
+ "mio",
+ "nix 0.29.0",
+ "serialport",
+ "winapi",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1869,7 +2186,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1905,6 +2222,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2118,7 +2450,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2152,6 +2484,47 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.25.4",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
@@ -2159,11 +2532,11 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
@@ -2175,9 +2548,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower",
  "tower-http",
  "tower-service",
@@ -2252,7 +2625,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2265,7 +2638,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -2298,6 +2671,15 @@ dependencies = [
  "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2441,6 +2823,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,6 +2865,24 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serialport"
+version = "4.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb0bc984f6af6ef8bab54e6cf2071579ee75b9286aa9f2319a0d220c28b0a2b"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "mach2",
+ "nix 0.26.4",
+ "scopeguard",
+ "unescaper",
+ "winapi",
 ]
 
 [[package]]
@@ -2590,6 +3000,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2606,6 +3022,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2739,11 +3176,35 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls 0.23.29",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-serial"
+version = "5.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1d5427f11ba7c5e6384521cfd76f2d64572ff29f3f4f7aa0f496282923fdc8"
+dependencies = [
+ "cfg-if",
+ "futures",
+ "log",
+ "mio-serial",
+ "serialport",
  "tokio",
 ]
 
@@ -2772,6 +3233,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,7 +3254,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2792,11 +3266,11 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -2873,6 +3347,15 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unescaper"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01d12e3a56a4432a8b436f293c25f4808bdf9e9f9f98f9260bba1f1bc5a1f26"
+dependencies = [
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -3127,11 +3610,20 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3140,7 +3632,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3149,15 +3656,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3167,9 +3680,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3185,9 +3710,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3197,9 +3734,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3208,12 +3757,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "cyberkrill",
     "cyberkrill-core",
     "fedimint-lite",
+    "jade-bitcoin",
 ]
 resolver = "2"
 

--- a/cyberkrill-core/Cargo.toml
+++ b/cyberkrill-core/Cargo.toml
@@ -14,6 +14,7 @@ smartcards = ["cktap-direct", "rusb"]
 frozenkrill = ["frozenkrill-core"]
 coldcard = ["dep:coldcard"]
 trezor = ["dep:trezor-client", "rusb"]
+jade = ["dep:jade-bitcoin"]
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }
@@ -46,6 +47,8 @@ frozenkrill-core = { git = "https://github.com/planktonlabs/frozenkrill", option
 coldcard = { git = "https://github.com/douglaz/rust-coldcard", branch = "hidraw", optional = true, default-features = false, features = ["hidraw-backend"] }
 # Trezor hardware wallet support (using master branch with bitcoin 0.32 support)
 trezor-client = { git = "https://github.com/trezor/trezor-firmware", package = "trezor-client", optional = true }
+# Jade hardware wallet support
+jade-bitcoin = { path = "../jade-bitcoin", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/cyberkrill-core/src/jade.rs
+++ b/cyberkrill-core/src/jade.rs
@@ -1,0 +1,136 @@
+//! Jade hardware wallet integration
+
+use anyhow::{bail, Context, Result};
+use jade_bitcoin::{JadeClient, Network as JadeNetwork};
+use serde::{Deserialize, Serialize};
+
+/// Result of Jade address generation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JadeAddressResult {
+    pub address: String,
+    pub path: String,
+    pub network: String,
+}
+
+/// Result of Jade xpub retrieval
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JadeXpubResult {
+    pub xpub: String,
+    pub path: String,
+    pub network: String,
+}
+
+/// Result of Jade PSBT signing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JadeSignedPsbtResult {
+    pub psbt: String,
+    pub psbt_hex: String,
+}
+
+/// Parse network string to Jade network enum
+fn parse_network(network: &str) -> Result<JadeNetwork> {
+    match network.to_lowercase().as_str() {
+        "bitcoin" | "mainnet" | "main" => Ok(JadeNetwork::Bitcoin),
+        "testnet" | "test" => Ok(JadeNetwork::Testnet),
+        "regtest" => Ok(JadeNetwork::Regtest),
+        "signet" => Ok(JadeNetwork::Signet),
+        _ => bail!(
+            "Invalid network: {}. Use mainnet, testnet, regtest, or signet",
+            network
+        ),
+    }
+}
+
+/// Generate a Bitcoin address from Jade
+pub async fn generate_jade_address(path: &str, network: &str) -> Result<JadeAddressResult> {
+    let jade_network = parse_network(network)?;
+
+    let mut client = JadeClient::connect()
+        .await
+        .context("Failed to connect to Jade device")?;
+
+    // Always try to unlock - the unlock method will check if already unlocked
+    client.unlock(jade_network)
+        .await
+        .context("Failed to unlock Jade device. Please ensure you enter the PIN on the device when prompted.")?;
+
+    // Give the device a moment after unlock
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let address = client
+        .get_address(path, jade_network)
+        .await
+        .context("Failed to get address from Jade")?;
+
+    Ok(JadeAddressResult {
+        address,
+        path: path.to_string(),
+        network: network.to_string(),
+    })
+}
+
+/// Get extended public key from Jade
+pub async fn generate_jade_xpub(path: &str, network: &str) -> Result<JadeXpubResult> {
+    let jade_network = parse_network(network)?;
+
+    let mut client = JadeClient::connect()
+        .await
+        .context("Failed to connect to Jade device")?;
+
+    // Always try to unlock - the unlock method will check if already unlocked
+    client.unlock(jade_network)
+        .await
+        .context("Failed to unlock Jade device. Please ensure you enter the PIN on the device when prompted.")?;
+
+    // Give the device a moment after unlock
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let xpub = client
+        .get_xpub(path)
+        .await
+        .context("Failed to get xpub from Jade")?;
+
+    Ok(JadeXpubResult {
+        xpub,
+        path: path.to_string(),
+        network: network.to_string(),
+    })
+}
+
+/// Sign a PSBT with Jade
+pub async fn sign_psbt_with_jade(psbt_input: &str, network: &str) -> Result<JadeSignedPsbtResult> {
+    let jade_network = parse_network(network)?;
+
+    // Parse PSBT from hex or base64
+    let psbt_bytes = if psbt_input.chars().all(|c| c.is_ascii_hexdigit()) {
+        hex::decode(psbt_input).context("Failed to decode PSBT from hex")?
+    } else {
+        base64::Engine::decode(&base64::engine::general_purpose::STANDARD, psbt_input)
+            .context("Failed to decode PSBT from base64")?
+    };
+
+    let mut client = JadeClient::connect()
+        .await
+        .context("Failed to connect to Jade device")?;
+
+    // Always try to unlock - the unlock method will check if already unlocked
+    client.unlock(jade_network)
+        .await
+        .context("Failed to unlock Jade device. Please ensure you enter the PIN on the device when prompted.")?;
+
+    // Give the device a moment after unlock
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    let signed_psbt = client
+        .sign_psbt(&psbt_bytes, jade_network)
+        .await
+        .context("Failed to sign PSBT with Jade")?;
+
+    let psbt_base64 =
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &signed_psbt);
+
+    Ok(JadeSignedPsbtResult {
+        psbt: psbt_base64,
+        psbt_hex: hex::encode(&signed_psbt),
+    })
+}

--- a/cyberkrill-core/src/lib.rs
+++ b/cyberkrill-core/src/lib.rs
@@ -16,6 +16,8 @@ pub mod trezor;
 #[cfg(feature = "coldcard")]
 pub mod coldcard;
 pub mod hardware_wallet;
+#[cfg(feature = "jade")]
+pub mod jade;
 
 // Re-export main functionality for easier access
 pub use decoder::{
@@ -60,4 +62,11 @@ pub use coldcard::{
 pub use trezor::{
     generate_trezor_address, sign_psbt_with_trezor, TrezorAddressOutput, TrezorSignOutput,
     TrezorWallet,
+};
+
+// Re-export jade functionality
+#[cfg(feature = "jade")]
+pub use jade::{
+    generate_jade_address, generate_jade_xpub, sign_psbt_with_jade, JadeAddressResult,
+    JadeSignedPsbtResult, JadeXpubResult,
 };

--- a/cyberkrill/Cargo.toml
+++ b/cyberkrill/Cargo.toml
@@ -12,6 +12,7 @@ smartcards = ["cyberkrill-core/smartcards"]
 frozenkrill = ["cyberkrill-core/frozenkrill"]
 coldcard = ["cyberkrill-core/coldcard"]
 trezor = ["cyberkrill-core/trezor"]
+jade = ["cyberkrill-core/jade"]
 
 [dependencies]
 anyhow = { version = "1.0.95", features = ["backtrace"] }

--- a/jade-bitcoin/Cargo.toml
+++ b/jade-bitcoin/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "jade-bitcoin"
+version = "0.1.0"
+edition = "2021"
+authors = ["CyberKrill Contributors"]
+description = "Bitcoin-focused Rust client for Blockstream Jade hardware wallet"
+repository = "https://github.com/douglaz/cyberkrill"
+license = "MIT OR Apache-2.0"
+keywords = ["bitcoin", "jade", "hardware-wallet", "blockstream"]
+categories = ["cryptography::cryptocurrencies", "hardware-support"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_cbor = "0.11"
+serde_json = "1.0"
+tokio-serial = "5.4"
+bitcoin = "0.32"
+hex = "0.4"
+thiserror = "1.0"
+log = "0.4"
+base64 = "0.22"
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"], optional = true }
+tokio = { version = "1", features = ["rt", "time", "io-util", "macros"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+anyhow = "1.0"
+env_logger = "0.11"
+
+[features]
+default = ["pinserver"]
+# Enable PIN server authentication support
+pinserver = ["reqwest"]
+# Feature for integration tests that require a real device
+integration-tests = []

--- a/jade-bitcoin/README.md
+++ b/jade-bitcoin/README.md
@@ -1,0 +1,80 @@
+# jade-bitcoin
+
+Bitcoin-focused Rust client for Blockstream Jade hardware wallet.
+
+## Features
+
+- Pure Rust implementation (no Python dependencies)
+- Bitcoin-only focus (no Liquid/Elements dependencies)
+- Auto-detection of Jade devices
+- Support for all Bitcoin networks (mainnet, testnet, regtest, signet)
+- BIP32/44/49/84/86 derivation paths
+- PSBT signing
+- Message signing
+- Clean, simple API
+
+## Installation
+
+```toml
+[dependencies]
+jade-bitcoin = "0.1"
+```
+
+## Usage
+
+```rust
+use jade_bitcoin::{JadeClient, Network};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Connect to Jade
+    let mut jade = JadeClient::connect()?;
+    
+    // Unlock for Bitcoin mainnet
+    jade.unlock(Network::Bitcoin)?;
+    
+    // Get a Bitcoin address
+    let address = jade.get_address("m/84'/0'/0'/0/0", Network::Bitcoin)?;
+    println!("Address: {}", address);
+    
+    // Get extended public key
+    let xpub = jade.get_xpub("m/84'/0'/0'")?;
+    println!("xpub: {}", xpub);
+    
+    // Sign a PSBT
+    let psbt_bytes = std::fs::read("transaction.psbt")?;
+    let signed = jade.sign_psbt(&psbt_bytes, Network::Bitcoin)?;
+    std::fs::write("signed.psbt", signed)?;
+    
+    Ok(())
+}
+```
+
+## Hardware Setup
+
+### Linux USB Permissions
+
+To access Jade without root privileges, add udev rules:
+
+```bash
+# /etc/udev/rules.d/51-jade.rules
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d4", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", MODE="0666"
+```
+
+Then reload udev rules:
+```bash
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+## Examples
+
+See the `examples/` directory for more usage examples:
+- `get_address.rs` - Generate Bitcoin addresses
+- `sign_psbt.rs` - Sign transactions
+- `get_xpub.rs` - Get extended public keys
+
+## License
+
+MIT OR Apache-2.0

--- a/jade-bitcoin/examples/get_address.rs
+++ b/jade-bitcoin/examples/get_address.rs
@@ -1,0 +1,64 @@
+//! Example: Generate Bitcoin address with Jade
+
+use jade_bitcoin::{JadeClient, Network};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    // Parse command line arguments
+    let args: Vec<String> = env::args().collect();
+    let path = args.get(1).map(|s| s.as_str()).unwrap_or("m/84'/0'/0'/0/0");
+    let network = args
+        .get(2)
+        .and_then(|s| match s.as_str() {
+            "mainnet" | "bitcoin" => Some(Network::Bitcoin),
+            "testnet" => Some(Network::Testnet),
+            "regtest" => Some(Network::Regtest),
+            "signet" => Some(Network::Signet),
+            _ => None,
+        })
+        .unwrap_or(Network::Bitcoin);
+
+    println!("Connecting to Jade...");
+
+    // List available devices
+    let devices = JadeClient::list_devices();
+    if devices.is_empty() {
+        eprintln!("No Jade devices found!");
+        eprintln!("Please connect your Jade device and ensure you have proper permissions.");
+        return Ok(());
+    }
+
+    println!("Found {} Jade device(s): {:?}", devices.len(), devices);
+
+    // Connect to Jade
+    let mut jade = JadeClient::connect()?;
+    println!("Connected to Jade");
+
+    // Get version info
+    let version = jade.get_version_info()?;
+    println!("Jade version: {}", version.jade_version);
+    println!("Board type: {}", version.board_type);
+
+    // Unlock the device
+    println!("\nUnlocking Jade for {:?}...", network);
+    println!("Please check your Jade device and confirm the operation");
+    jade.unlock(network)?;
+    println!("Jade unlocked");
+
+    // Generate address
+    println!("\nGenerating address for path: {}", path);
+    let address = jade.get_address(path, network)?;
+
+    println!("\n=== Bitcoin Address ===");
+    println!("Path:    {}", path);
+    println!("Network: {:?}", network);
+    println!("Address: {}", address);
+
+    // Logout
+    jade.logout()?;
+    println!("\nLogged out from Jade");
+
+    Ok(())
+}

--- a/jade-bitcoin/examples/get_xpub.rs
+++ b/jade-bitcoin/examples/get_xpub.rs
@@ -1,0 +1,64 @@
+//! Example: Get extended public key from Jade
+
+use jade_bitcoin::{JadeClient, Network};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    // Parse command line arguments
+    let args: Vec<String> = env::args().collect();
+    let path = args.get(1).map(|s| s.as_str()).unwrap_or("m/84'/0'/0'");
+
+    println!("Connecting to Jade...");
+
+    // Connect to Jade
+    let mut jade = JadeClient::connect()?;
+    println!("Connected to Jade");
+
+    // Get version info
+    let version = jade.get_version_info()?;
+    println!("Jade version: {}", version.jade_version);
+
+    // Unlock the device (xpub works with any network)
+    println!("\nUnlocking Jade...");
+    println!("Please check your Jade device and confirm the operation");
+    jade.unlock(Network::Bitcoin)?;
+    println!("Jade unlocked");
+
+    // Get extended public key
+    println!("\nGetting xpub for path: {}", path);
+    let xpub = jade.get_xpub(path)?;
+
+    println!("\n=== Extended Public Key ===");
+    println!("Path: {}", path);
+    println!("xpub: {}", xpub);
+
+    // Demonstrate getting multiple xpubs
+    println!("\n=== Additional xpubs ===");
+
+    // Account 0 for different purposes
+    for (purpose, name) in &[
+        (44, "Legacy (P2PKH)"),
+        (49, "Nested SegWit (P2SH-P2WPKH)"),
+        (84, "Native SegWit (P2WPKH)"),
+        (86, "Taproot (P2TR)"),
+    ] {
+        let account_path = format!("m/{}'/{}'/{}'", purpose, 0, 0);
+        match jade.get_xpub(&account_path) {
+            Ok(xpub) => {
+                println!("\n{} - {}", name, account_path);
+                println!("{}", xpub);
+            }
+            Err(e) => {
+                eprintln!("Failed to get xpub for {}: {}", account_path, e);
+            }
+        }
+    }
+
+    // Logout
+    jade.logout()?;
+    println!("\nLogged out from Jade");
+
+    Ok(())
+}

--- a/jade-bitcoin/examples/get_xpub_quick.rs
+++ b/jade-bitcoin/examples/get_xpub_quick.rs
@@ -1,0 +1,38 @@
+//! Example: Get extended public key from Jade (assumes already unlocked)
+
+use jade_bitcoin::{JadeClient, Network};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    // Parse command line arguments
+    let args: Vec<String> = env::args().collect();
+    let path = args.get(1).map(|s| s.as_str()).unwrap_or("m/84'/0'/0'");
+
+    println!("Connecting to Jade...");
+
+    // Connect to Jade
+    let mut jade = JadeClient::connect()?;
+    println!("Connected to Jade");
+
+    // Try to unlock for testnet (or check if already unlocked)
+    println!("Checking device status...");
+    match jade.unlock(Network::Testnet) {
+        Ok(_) => println!("Device unlocked"),
+        Err(e) => {
+            // If already unlocked, this might succeed anyway
+            println!("Note: {}", e);
+        }
+    }
+
+    // Get extended public key
+    println!("\nGetting xpub for path: {}", path);
+    let xpub = jade.get_xpub(path)?;
+
+    println!("\n=== Extended Public Key ===");
+    println!("Path: {}", path);
+    println!("xpub: {}", xpub);
+
+    Ok(())
+}

--- a/jade-bitcoin/examples/get_xpub_test.rs
+++ b/jade-bitcoin/examples/get_xpub_test.rs
@@ -1,0 +1,49 @@
+//! Example: Get extended public key from Jade with network selection
+
+use jade_bitcoin::{JadeClient, Network};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    // Parse command line arguments
+    let args: Vec<String> = env::args().collect();
+    let path = args.get(1).map(|s| s.as_str()).unwrap_or("m/84'/0'/0'");
+    let network_str = args.get(2).map(|s| s.as_str()).unwrap_or("testnet");
+
+    let network = match network_str {
+        "mainnet" | "bitcoin" => Network::Bitcoin,
+        "testnet" => Network::Testnet,
+        "regtest" => Network::Regtest,
+        "signet" => Network::Signet,
+        _ => {
+            eprintln!(
+                "Invalid network: {}. Use mainnet, testnet, regtest, or signet",
+                network_str
+            );
+            return Ok(());
+        }
+    };
+
+    println!("Connecting to Jade...");
+
+    // Connect to Jade
+    let mut jade = JadeClient::connect()?;
+    println!("Connected to Jade");
+
+    // Try to unlock for the specified network
+    println!("Unlocking device for {:?}...", network);
+    jade.unlock(network)?;
+    println!("Device unlocked");
+
+    // Get extended public key
+    println!("\nGetting xpub for path: {}", path);
+    let xpub = jade.get_xpub(path)?;
+
+    println!("\n=== Extended Public Key ===");
+    println!("Network: {:?}", network);
+    println!("Path: {}", path);
+    println!("xpub: {}", xpub);
+
+    Ok(())
+}

--- a/jade-bitcoin/examples/sign_psbt.rs
+++ b/jade-bitcoin/examples/sign_psbt.rs
@@ -1,0 +1,71 @@
+//! Example: Sign PSBT with Jade
+
+use jade_bitcoin::{JadeClient, Network};
+use std::env;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    // Parse command line arguments
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <psbt_file> [network]", args[0]);
+        eprintln!("  psbt_file: Path to PSBT file to sign");
+        eprintln!("  network: bitcoin|testnet|regtest|signet (default: bitcoin)");
+        return Ok(());
+    }
+
+    let psbt_file = &args[1];
+    let network = args
+        .get(2)
+        .and_then(|s| match s.as_str() {
+            "mainnet" | "bitcoin" => Some(Network::Bitcoin),
+            "testnet" => Some(Network::Testnet),
+            "regtest" => Some(Network::Regtest),
+            "signet" => Some(Network::Signet),
+            _ => None,
+        })
+        .unwrap_or(Network::Bitcoin);
+
+    // Read PSBT file
+    println!("Reading PSBT from: {}", psbt_file);
+    let psbt_bytes = fs::read(psbt_file)?;
+    println!("PSBT size: {} bytes", psbt_bytes.len());
+
+    println!("\nConnecting to Jade...");
+
+    // Connect to Jade
+    let mut jade = JadeClient::connect()?;
+    println!("Connected to Jade");
+
+    // Get version info
+    let version = jade.get_version_info()?;
+    println!("Jade version: {}", version.jade_version);
+
+    // Unlock the device
+    println!("\nUnlocking Jade for {:?}...", network);
+    println!("Please check your Jade device and confirm the operation");
+    jade.unlock(network)?;
+    println!("Jade unlocked");
+
+    // Sign the PSBT
+    println!("\nSigning PSBT...");
+    println!("Please review and confirm the transaction on your Jade device");
+
+    let signed_psbt = jade.sign_psbt(&psbt_bytes, network)?;
+
+    println!("PSBT signed successfully!");
+    println!("Signed PSBT size: {} bytes", signed_psbt.len());
+
+    // Save signed PSBT
+    let output_file = psbt_file.replace(".psbt", "_signed.psbt");
+    fs::write(&output_file, signed_psbt)?;
+    println!("Signed PSBT saved to: {}", output_file);
+
+    // Logout
+    jade.logout()?;
+    println!("\nLogged out from Jade");
+
+    Ok(())
+}

--- a/jade-bitcoin/examples/test_simple.rs
+++ b/jade-bitcoin/examples/test_simple.rs
@@ -1,0 +1,39 @@
+//! Simple test to diagnose connection issues
+
+use jade_bitcoin::{JadeClient, Network};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    println!("Starting simple Jade test...");
+
+    // Just try to connect
+    println!("Attempting to connect to Jade...");
+    let mut client = JadeClient::connect().await?;
+    println!("Connected!");
+
+    // Try to get version
+    println!("Getting version info...");
+    let version = client.get_version_info().await?;
+    println!("Version: {:?}", version);
+
+    // Check if unlocked
+    println!("Checking unlock status...");
+    let unlocked = client.is_unlocked().await;
+    println!("Unlocked: {}", unlocked);
+
+    if !unlocked {
+        println!("Device is locked. Attempting to unlock for mainnet...");
+        client.unlock(Network::Bitcoin).await?;
+        println!("Unlock successful!");
+    }
+
+    // Try to get xpub
+    println!("Getting xpub...");
+    let xpub = client.get_xpub("m/84'/0'/0'").await?;
+    println!("xpub: {}", xpub);
+
+    println!("Test completed successfully!");
+    Ok(())
+}

--- a/jade-bitcoin/examples/test_unlock.rs
+++ b/jade-bitcoin/examples/test_unlock.rs
@@ -1,0 +1,60 @@
+//! Test unlocking Jade with better logging
+
+use jade_bitcoin::{JadeClient, Network};
+use std::io;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    println!("Jade Unlock Test");
+    println!("================");
+
+    // Connect to Jade
+    println!("Connecting to Jade...");
+    let mut client = JadeClient::connect().await?;
+    println!("✓ Connected");
+
+    // Check version
+    println!("\nGetting version info...");
+    let version = client.get_version_info().await?;
+    println!("✓ Version: {}", version.jade_version);
+    println!("  State: {}", version.jade_state);
+
+    // Check if already unlocked
+    if client.is_unlocked().await {
+        println!("\n✓ Device is already unlocked!");
+    } else {
+        println!("\n⚠ Device is locked. Starting unlock process...");
+        println!("Please be ready to enter your PIN on the Jade device when prompted.");
+        println!("Press Enter to continue...");
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+
+        println!("Unlocking for mainnet...");
+        match client.unlock(Network::Bitcoin).await {
+            Ok(()) => {
+                println!("✓ Device unlocked successfully!");
+            }
+            Err(e) => {
+                println!("✗ Failed to unlock: {}", e);
+                return Err(e.into());
+            }
+        }
+    }
+
+    // Test getting xpub
+    println!("\nTesting xpub retrieval...");
+    match client.get_xpub("m/84'/0'/0'").await {
+        Ok(xpub) => {
+            println!("✓ Got xpub: {}", &xpub[..20]);
+        }
+        Err(e) => {
+            println!("✗ Failed to get xpub: {}", e);
+        }
+    }
+
+    println!("\n✓ Test completed successfully!");
+    Ok(())
+}

--- a/jade-bitcoin/examples/test_version.rs
+++ b/jade-bitcoin/examples/test_version.rs
@@ -1,0 +1,40 @@
+//! Simple test to get version info from Jade
+
+use jade_bitcoin::JadeClient;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_default_env()
+        .filter_level(log::LevelFilter::Debug)
+        .init();
+
+    println!("Connecting to Jade...");
+
+    // List available devices
+    let devices = JadeClient::list_devices();
+    println!("Found {} device(s): {:?}", devices.len(), devices);
+
+    if devices.is_empty() {
+        eprintln!("No Jade devices found!");
+        return Ok(());
+    }
+
+    // Connect to Jade
+    let mut jade = JadeClient::connect()?;
+    println!("Connected to Jade");
+
+    // Just try to get version info - this should work without unlock
+    println!("\nGetting version info...");
+    match jade.get_version_info() {
+        Ok(version) => {
+            println!("Success! Jade version: {}", version.jade_version);
+            println!("Board type: {}", version.board_type);
+            println!("Config: {}", version.jade_config);
+            println!("Has PIN: {}", version.jade_has_pin);
+        }
+        Err(e) => {
+            eprintln!("Failed to get version info: {}", e);
+        }
+    }
+
+    Ok(())
+}

--- a/jade-bitcoin/src/client.rs
+++ b/jade-bitcoin/src/client.rs
@@ -1,0 +1,248 @@
+//! High-level Jade client API
+
+use crate::error::{Error, Result};
+use crate::protocol::JadeProtocol;
+use crate::serial::SerialConnection;
+use crate::types::{Network, VersionInfo};
+use bitcoin::bip32::DerivationPath;
+use log::{debug, info};
+use std::str::FromStr;
+
+/// High-level client for Jade hardware wallet
+pub struct JadeClient {
+    protocol: JadeProtocol,
+    current_network: Option<Network>,
+}
+
+impl JadeClient {
+    /// Connect to Jade device on any available port
+    pub async fn connect() -> Result<Self> {
+        info!("Searching for Jade device...");
+        let connection = SerialConnection::connect().await?;
+        let protocol = JadeProtocol::new(connection);
+
+        Ok(Self {
+            protocol,
+            current_network: None,
+        })
+    }
+
+    /// Connect to Jade device on specific port
+    pub async fn connect_path(path: &str) -> Result<Self> {
+        info!("Connecting to Jade on {path}");
+        let connection = SerialConnection::connect_path(path).await?;
+        let protocol = JadeProtocol::new(connection);
+
+        Ok(Self {
+            protocol,
+            current_network: None,
+        })
+    }
+
+    /// List all available Jade devices
+    pub fn list_devices() -> Vec<String> {
+        SerialConnection::list_devices()
+    }
+
+    /// Get device version information
+    pub async fn get_version_info(&mut self) -> Result<VersionInfo> {
+        debug!("Getting version info");
+        let result = self.protocol.get_version_info().await?;
+
+        serde_json::from_value(result).map_err(|_| Error::InvalidResponse)
+    }
+
+    /// Unlock the device for a specific network
+    pub async fn unlock(&mut self, network: Network) -> Result<()> {
+        info!("Unlocking Jade for {network:?}");
+
+        // Check if already unlocked for this network
+        if self.current_network == Some(network) {
+            // Try a simple operation to verify the connection is still valid
+            match self.get_version_info().await {
+                Ok(_) => {
+                    info!("Jade already unlocked for {network:?}");
+                    return Ok(());
+                }
+                Err(_) => {
+                    // Connection might be stale, continue with unlock
+                    self.current_network = None;
+                }
+            }
+        }
+
+        // First get version to ensure device is responsive
+        let _version = self.get_version_info().await?;
+
+        // Authenticate with the network
+        self.protocol.auth_user(network).await?;
+        self.current_network = Some(network);
+
+        info!("Jade unlocked successfully");
+        Ok(())
+    }
+
+    /// Check if device is already unlocked (without trying to unlock)
+    pub async fn is_unlocked(&mut self) -> bool {
+        info!("Checking if Jade is unlocked...");
+        // Try to get version info with current auth state
+        match self.protocol.get_version_info().await {
+            Ok(info) => {
+                debug!("Version info received: {info:?}");
+                // Check if the info indicates an unlocked state
+                if let Some(state) = info.get("JADE_STATE").and_then(|v| v.as_str()) {
+                    let unlocked = state != "LOCKED";
+                    info!("Jade state: {state} (unlocked: {unlocked})");
+
+                    // If device is ready, set the current network to Bitcoin (mainnet) by default
+                    // The device doesn't tell us which network it's on, so we assume mainnet
+                    if unlocked && self.current_network.is_none() {
+                        self.current_network = Some(Network::Bitcoin);
+                        info!("Device is unlocked, assuming mainnet network");
+                    }
+
+                    unlocked
+                } else {
+                    info!("No JADE_STATE found in version info");
+                    false
+                }
+            }
+            Err(e) => {
+                info!("Failed to get version info: {e:?}");
+                false
+            }
+        }
+    }
+
+    /// Logout from the device
+    pub async fn logout(&mut self) -> Result<()> {
+        info!("Logging out from Jade");
+        self.protocol.logout().await?;
+        self.current_network = None;
+        Ok(())
+    }
+
+    /// Get extended public key at derivation path
+    pub async fn get_xpub(&mut self, path: &str) -> Result<String> {
+        debug!("Getting xpub for path: {path}");
+
+        // Check if device is unlocked
+        if self.current_network.is_none() {
+            return Err(Error::DeviceLocked);
+        }
+
+        let path_array = parse_derivation_path(path)?;
+        let network = self.current_network.unwrap();
+        self.protocol.get_xpub(&path_array, network).await
+    }
+
+    /// Get Bitcoin address at derivation path
+    pub async fn get_address(&mut self, path: &str, network: Network) -> Result<String> {
+        debug!("Getting address for path: {path} on {network:?}");
+
+        // Check if we need to switch networks
+        if let Some(current) = self.current_network {
+            if current != network {
+                return Err(Error::NetworkMismatch {
+                    device: format!("{current:?}"),
+                    requested: format!("{network:?}"),
+                });
+            }
+        } else {
+            return Err(Error::DeviceLocked);
+        }
+
+        let path_array = parse_derivation_path(path)?;
+
+        // Determine address variant based on path
+        let variant = determine_address_variant(&path_array);
+
+        self.protocol
+            .get_receive_address(network, &path_array, variant)
+            .await
+    }
+
+    /// Sign a PSBT (Partially Signed Bitcoin Transaction)
+    pub async fn sign_psbt(&mut self, psbt: &[u8], network: Network) -> Result<Vec<u8>> {
+        debug!("Signing PSBT for {network:?}");
+
+        // Check network
+        if let Some(current) = self.current_network {
+            if current != network {
+                return Err(Error::NetworkMismatch {
+                    device: format!("{current:?}"),
+                    requested: format!("{network:?}"),
+                });
+            }
+        } else {
+            return Err(Error::DeviceLocked);
+        }
+
+        let result = self.protocol.sign_psbt(network, psbt).await?;
+
+        // Extract the signed PSBT from response
+        if let Some(psbt_str) = result.get("psbt").and_then(|v| v.as_str()) {
+            // Decode base64 PSBT
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, psbt_str)
+                .map_err(|_| Error::InvalidResponse)
+        } else {
+            Err(Error::InvalidResponse)
+        }
+    }
+
+    /// Sign a message with a specific derivation path
+    pub async fn sign_message(&mut self, message: &str, path: &str) -> Result<String> {
+        debug!("Signing message with path: {path}");
+
+        if self.current_network.is_none() {
+            return Err(Error::DeviceLocked);
+        }
+
+        let path_array = parse_derivation_path(path)?;
+        self.protocol
+            .sign_message(&path_array, message, false)
+            .await
+    }
+}
+
+/// Parse BIP32 derivation path
+fn parse_derivation_path(path: &str) -> Result<Vec<u32>> {
+    // Parse using bitcoin crate's DerivationPath
+    let derivation =
+        DerivationPath::from_str(path).map_err(|_| Error::InvalidPath(path.to_string()))?;
+
+    // Convert to u32 array for Jade
+    let path_array: Vec<u32> = derivation
+        .into_iter()
+        .map(|child| {
+            let index = u32::from(*child);
+            // Jade expects hardened paths to have the high bit set
+            if child.is_hardened() {
+                index | 0x80000000
+            } else {
+                index
+            }
+        })
+        .collect();
+
+    Ok(path_array)
+}
+
+/// Determine address variant based on derivation path
+fn determine_address_variant(path: &[u32]) -> Option<&'static str> {
+    if path.is_empty() {
+        return None;
+    }
+
+    // Check the first component (purpose) to determine address type
+    // Remove hardening bit for comparison
+    let purpose = path[0] & 0x7FFFFFFF;
+
+    match purpose {
+        44 => Some("pkh(k)"),      // Legacy P2PKH
+        49 => Some("sh(wpkh(k))"), // Nested SegWit P2SH-P2WPKH
+        84 => Some("wpkh(k)"),     // Native SegWit P2WPKH
+        86 => Some("tr(k)"),       // Taproot P2TR
+        _ => None,
+    }
+}

--- a/jade-bitcoin/src/error.rs
+++ b/jade-bitcoin/src/error.rs
@@ -1,0 +1,56 @@
+//! Error types for jade-bitcoin
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Serial port error: {0}")]
+    SerialPort(#[from] tokio_serial::Error),
+
+    #[error("CBOR encoding error: {0}")]
+    CborEncode(#[from] serde_cbor::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("No Jade device found")]
+    DeviceNotFound,
+
+    #[error("Jade device error: code={code}, message={message}")]
+    JadeError { code: i32, message: String },
+
+    #[error("Invalid response from Jade")]
+    InvalidResponse,
+
+    #[error("User cancelled operation on device")]
+    UserCancelled,
+
+    #[error("Device is locked")]
+    DeviceLocked,
+
+    #[error("Invalid derivation path: {0}")]
+    InvalidPath(String),
+
+    #[error("Network mismatch: device is on {device}, requested {requested}")]
+    NetworkMismatch { device: String, requested: String },
+
+    #[error("Timeout waiting for device response")]
+    Timeout,
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Bitcoin error: {0}")]
+    Bitcoin(#[from] bitcoin::address::ParseError),
+
+    #[error("Invalid PSBT")]
+    InvalidPsbt,
+
+    #[error("Hex decode error: {0}")]
+    Hex(#[from] hex::FromHexError),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/jade-bitcoin/src/lib.rs
+++ b/jade-bitcoin/src/lib.rs
@@ -1,0 +1,42 @@
+//! Bitcoin-focused Rust client for Blockstream Jade hardware wallet
+//!
+//! This crate provides a clean, Bitcoin-only interface for interacting with
+//! Jade hardware wallets. It handles serial communication, CBOR protocol,
+//! and provides simple methods for common Bitcoin operations.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use jade_bitcoin::{JadeClient, Network};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Connect to Jade device
+//! let mut jade = JadeClient::connect()?;
+//!
+//! // Unlock the device
+//! jade.unlock(Network::Bitcoin)?;
+//!
+//! // Get a Bitcoin address
+//! let address = jade.get_address("m/84'/0'/0'/0/0", Network::Bitcoin)?;
+//! println!("Address: {}", address);
+//!
+//! // Get extended public key
+//! let xpub = jade.get_xpub("m/84'/0'/0'")?;
+//! println!("xpub: {}", xpub);
+//! # Ok(())
+//! # }
+//! ```
+
+mod client;
+mod error;
+mod messages;
+mod protocol;
+mod serial;
+mod types;
+
+pub use client::JadeClient;
+pub use error::{Error, Result};
+pub use types::{Network, VersionInfo};
+
+// Re-export commonly used types
+pub use bitcoin::psbt::Psbt;

--- a/jade-bitcoin/src/messages.rs
+++ b/jade-bitcoin/src/messages.rs
@@ -1,0 +1,82 @@
+//! CBOR message structures for Jade protocol
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Request message to Jade
+#[derive(Debug, Serialize)]
+pub struct Request {
+    pub id: String,
+    pub method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+}
+
+impl Request {
+    pub fn new(id: impl Into<String>, method: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            method: method.into(),
+            params: None,
+        }
+    }
+
+    pub fn with_params(id: impl Into<String>, method: impl Into<String>, params: Value) -> Self {
+        Self {
+            id: id.into(),
+            method: method.into(),
+            params: Some(params),
+        }
+    }
+}
+
+/// Response message from Jade
+#[derive(Debug, Deserialize)]
+pub struct Response {
+    pub id: String,
+    #[serde(flatten)]
+    pub body: ResponseBody,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum ResponseBody {
+    Result { result: Value },
+    Error { error: ErrorResponse },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ErrorResponse {
+    pub code: i32,
+    pub message: String,
+    #[serde(default)]
+    pub data: Option<Value>,
+}
+
+/// Methods supported by Jade
+pub mod methods {
+    pub const GET_VERSION_INFO: &str = "get_version_info";
+    pub const AUTH_USER: &str = "auth_user";
+    pub const LOGOUT: &str = "logout";
+    pub const GET_XPUB: &str = "get_xpub";
+    pub const GET_RECEIVE_ADDRESS: &str = "get_receive_address";
+    pub const SIGN_PSBT: &str = "sign_psbt";
+    pub const SIGN_MESSAGE: &str = "sign_message";
+    pub const GET_MASTER_BLINDING_KEY: &str = "get_master_blinding_key";
+    pub const GET_SHARED_NONCE: &str = "get_shared_nonce";
+    pub const GET_COMMITMENTS: &str = "get_commitments";
+    pub const GET_SIGNATURE: &str = "get_signature";
+    pub const HTTP_REQUEST: &str = "http_request";
+}
+
+/// Error codes from Jade
+pub mod error_codes {
+    pub const USER_CANCELLED: i32 = -32000;
+    pub const INVALID_REQUEST: i32 = -32600;
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    pub const INTERNAL_ERROR: i32 = -32603;
+    pub const HW_LOCKED: i32 = -32001;
+    pub const NETWORK_MISMATCH: i32 = -32002;
+    pub const USER_DECLINED: i32 = -32003;
+}

--- a/jade-bitcoin/src/protocol.rs
+++ b/jade-bitcoin/src/protocol.rs
@@ -1,0 +1,357 @@
+//! Jade protocol implementation
+
+use crate::error::{Error, Result};
+use crate::messages::{error_codes, methods, Request, ResponseBody};
+use crate::serial::SerialConnection;
+use crate::types::Network;
+use log::{debug, info};
+use serde_json::{json, Value};
+
+/// Low-level protocol handler for Jade communication
+pub struct JadeProtocol {
+    connection: SerialConnection,
+    message_counter: u32,
+}
+
+impl JadeProtocol {
+    /// Create new protocol handler with connection
+    pub fn new(connection: SerialConnection) -> Self {
+        Self {
+            connection,
+            message_counter: 0,
+        }
+    }
+
+    /// Get next message ID
+    fn next_id(&mut self) -> String {
+        self.message_counter += 1;
+        self.message_counter.to_string()
+    }
+
+    /// Send request and get response
+    pub async fn call(&mut self, method: &str, params: Option<Value>) -> Result<Value> {
+        let id = self.next_id();
+        let request = if let Some(params) = params {
+            Request::with_params(id.clone(), method, params)
+        } else {
+            Request::new(id.clone(), method)
+        };
+
+        let response = self.connection.request(&request).await?;
+
+        // Verify response ID matches request
+        if response.id != id {
+            return Err(Error::InvalidResponse);
+        }
+
+        // Handle response
+        match response.body {
+            ResponseBody::Result { result } => Ok(result),
+            ResponseBody::Error { error } => {
+                // Handle specific error codes
+                match error.code {
+                    error_codes::USER_CANCELLED | error_codes::USER_DECLINED => {
+                        Err(Error::UserCancelled)
+                    }
+                    error_codes::HW_LOCKED => Err(Error::DeviceLocked),
+                    _ => Err(Error::JadeError {
+                        code: error.code,
+                        message: error.message,
+                    }),
+                }
+            }
+        }
+    }
+
+    /// Get device version information
+    pub async fn get_version_info(&mut self) -> Result<Value> {
+        self.call(methods::GET_VERSION_INFO, None).await
+    }
+
+    /// Authenticate user with network
+    pub async fn auth_user(&mut self, network: Network) -> Result<()> {
+        info!("Starting auth_user for network: {network:?}");
+
+        let params = json!({
+            "network": network.as_jade_str()
+        });
+
+        // Send initial auth request
+        let id = self.next_id();
+        let request = Request::with_params(id.clone(), methods::AUTH_USER, params);
+        debug!("Sending auth_user request with id: {id}");
+        let response = self.connection.request(&request).await?;
+
+        match response.body {
+            ResponseBody::Result { result } => {
+                // Check if already authenticated
+                if let Some(true) = result.as_bool() {
+                    info!("Device already authenticated");
+                    return Ok(());
+                }
+
+                // If not a simple true, we need PIN server auth
+                // For now, return an error indicating PIN server is needed
+                #[cfg(not(feature = "pinserver"))]
+                return Err(Error::Other(
+                    "PIN authentication required but pinserver feature not enabled".to_string(),
+                ));
+
+                #[cfg(feature = "pinserver")]
+                {
+                    // The result contains the first HTTP request
+                    info!("PIN authentication required, starting PIN server flow");
+                    self.handle_pinserver_auth_with_initial(network, result, &id)
+                        .await?;
+                    Ok(())
+                }
+            }
+            ResponseBody::Error { error } => match error.code {
+                error_codes::USER_CANCELLED | error_codes::USER_DECLINED => {
+                    Err(Error::UserCancelled)
+                }
+                error_codes::HW_LOCKED => Err(Error::DeviceLocked),
+                _ => Err(Error::JadeError {
+                    code: error.code,
+                    message: error.message,
+                }),
+            },
+        }
+    }
+
+    /// Logout from device
+    pub async fn logout(&mut self) -> Result<()> {
+        self.call(methods::LOGOUT, None).await?;
+        Ok(())
+    }
+
+    /// Get extended public key
+    pub async fn get_xpub(&mut self, path: &[u32], network: Network) -> Result<String> {
+        let params = json!({
+            "path": path,
+            "network": network.as_jade_str()
+        });
+
+        let result = self.call(methods::GET_XPUB, Some(params)).await?;
+
+        result
+            .as_str()
+            .map(String::from)
+            .ok_or(Error::InvalidResponse)
+    }
+
+    /// Get receive address
+    pub async fn get_receive_address(
+        &mut self,
+        network: Network,
+        path: &[u32],
+        variant: Option<&str>,
+    ) -> Result<String> {
+        let mut params = json!({
+            "path": path,
+            "network": network.as_jade_str()
+        });
+
+        if let Some(variant) = variant {
+            params["variant"] = json!(variant);
+        }
+
+        let result = self
+            .call(methods::GET_RECEIVE_ADDRESS, Some(params))
+            .await?;
+
+        result
+            .as_str()
+            .map(String::from)
+            .ok_or(Error::InvalidResponse)
+    }
+
+    /// Sign a PSBT
+    pub async fn sign_psbt(&mut self, network: Network, psbt_bytes: &[u8]) -> Result<Value> {
+        // Encode PSBT as base64 for transmission
+        let psbt_base64 =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, psbt_bytes);
+
+        let params = json!({
+            "network": network.as_jade_str(),
+            "psbt": psbt_base64
+        });
+
+        self.call(methods::SIGN_PSBT, Some(params)).await
+    }
+
+    /// Sign a message
+    pub async fn sign_message(
+        &mut self,
+        path: &[u32],
+        message: &str,
+        use_ae_protocol: bool,
+    ) -> Result<String> {
+        let params = json!({
+            "path": path,
+            "message": message,
+            "use_ae_protocol": use_ae_protocol
+        });
+
+        let result = self.call(methods::SIGN_MESSAGE, Some(params)).await?;
+
+        result
+            .as_str()
+            .map(String::from)
+            .ok_or(Error::InvalidResponse)
+    }
+
+    #[cfg(feature = "pinserver")]
+    async fn handle_pinserver_auth_with_initial(
+        &mut self,
+        _network: Network,
+        initial_result: Value,
+        auth_id: &str,
+    ) -> Result<()> {
+        use reqwest::Client;
+
+        info!("Starting PIN server authentication");
+        let client = Client::new();
+
+        // Process the initial HTTP request from the auth_user response
+        if let Some(http_req) = initial_result.get("http_request") {
+            self.process_http_request(&client, http_req).await?;
+        } else {
+            return Err(Error::Other(
+                "Expected http_request in auth response".to_string(),
+            ));
+        }
+
+        // Continue processing any additional HTTP requests
+        self.handle_pinserver_auth_loop(&client, auth_id).await
+    }
+
+    #[cfg(feature = "pinserver")]
+    async fn handle_pinserver_auth_loop(
+        &mut self,
+        client: &reqwest::Client,
+        auth_id: &str,
+    ) -> Result<()> {
+        loop {
+            info!("Waiting for next message from Jade in PIN auth loop...");
+            // Read next message from Jade
+            let response = self.connection.receive_response().await?;
+
+            info!(
+                "Received response with id: {} (looking for: {})",
+                response.id, auth_id
+            );
+
+            match response.body {
+                ResponseBody::Result { result } => {
+                    // Check if this is another HTTP request
+                    if let Some(http_req) = result.get("http_request") {
+                        info!("Received another HTTP request from Jade");
+                        self.process_http_request(client, http_req).await?;
+                        continue;
+                    }
+
+                    // If it's a boolean true, check if it's the final auth response
+                    if let Some(true) = result.as_bool() {
+                        if response.id == auth_id {
+                            info!("Authentication successful!");
+                            return Ok(());
+                        } else {
+                            info!(
+                                "Jade acknowledged message with id: {}, continuing...",
+                                response.id
+                            );
+                            // This might be the final success, wait a bit and return
+                            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                            return Ok(());
+                        }
+                    }
+
+                    debug!("Unexpected result in PIN auth loop: {result:?}");
+                    continue;
+                }
+                ResponseBody::Error { error } => {
+                    return Err(Error::JadeError {
+                        code: error.code,
+                        message: error.message,
+                    });
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "pinserver")]
+    async fn process_http_request(
+        &mut self,
+        client: &reqwest::Client,
+        http_req: &Value,
+    ) -> Result<()> {
+        // Extract the HTTP request parameters
+        let params = http_req
+            .get("params")
+            .ok_or_else(|| Error::Other("Missing params in http_request".to_string()))?;
+
+        let urls = params["urls"]
+            .as_array()
+            .ok_or_else(|| Error::Other("Missing urls in http_request".to_string()))?;
+
+        let url = urls.first()
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Other("No URL provided".to_string()))?;
+
+        let method = params["method"].as_str().unwrap_or("POST");
+        let data = params.get("data");
+        let on_reply = http_req
+            .get("on-reply")
+            .and_then(|v| v.as_str())
+            .unwrap_or("pin");
+
+        debug!("Making {method} request to {url}");
+
+        // Make the HTTP request
+        let http_response = if method == "POST" {
+            let mut req = client.post(url);
+            if let Some(data) = data {
+                req = req.json(data);
+            }
+            req.send()
+                .await
+                .map_err(|e| Error::Other(format!("HTTP request failed: {e}")))?
+        } else {
+            client
+                .get(url)
+                .send()
+                .await
+                .map_err(|e| Error::Other(format!("HTTP request failed: {e}")))?
+        };
+
+        // Get response body as text
+        let body = http_response
+            .text()
+            .await
+            .map_err(|e| Error::Other(format!("Failed to read response: {e}")))?;
+
+        debug!("PIN server response: {} bytes", body.len());
+
+        // Parse response as JSON if possible
+        let response_data = if let Ok(json) = serde_json::from_str::<Value>(&body) {
+            json
+        } else {
+            json!({"body": body})
+        };
+
+        // Send response back to Jade with the correct method name
+        let reply_id = self.next_id();
+        let reply = Request::with_params(
+            reply_id.clone(),
+            on_reply, // Use the on-reply field as the method name
+            response_data,
+        );
+
+        debug!("Sending {on_reply} reply to Jade with id: {reply_id}");
+        // Don't wait for a response here, just send the reply
+        self.connection.send_request(&reply).await?;
+
+        Ok(())
+    }
+}

--- a/jade-bitcoin/src/serial.rs
+++ b/jade-bitcoin/src/serial.rs
@@ -1,0 +1,210 @@
+//! Serial port communication for Jade (async implementation)
+
+use crate::error::{Error, Result};
+use crate::messages::{Request, Response};
+use crate::types::{JADE_USB_IDS, SERIAL_BAUD_RATE, SERIAL_TIMEOUT_MS};
+use log::debug;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::time::{sleep, timeout, Duration};
+use tokio_serial::{SerialPortBuilderExt, SerialStream};
+
+/// Async serial connection to Jade device
+pub struct SerialConnection {
+    port: SerialStream,
+    read_buffer: Vec<u8>,
+}
+
+impl SerialConnection {
+    /// Connect to Jade on any available port
+    pub async fn connect() -> Result<Self> {
+        let ports = Self::find_jade_ports();
+        if ports.is_empty() {
+            debug!("No Jade devices found");
+            return Err(Error::DeviceNotFound);
+        }
+
+        debug!("Found {} potential Jade device(s)", ports.len());
+        // Try each port until one works
+        for port_info in ports {
+            debug!("Attempting to connect to Jade on {}", port_info.port_name);
+            match Self::connect_path(&port_info.port_name).await {
+                Ok(conn) => {
+                    debug!("Successfully connected to Jade on {}", port_info.port_name);
+                    return Ok(conn);
+                }
+                Err(e) => {
+                    debug!("Failed to connect to {}: {}", port_info.port_name, e);
+                }
+            }
+        }
+
+        Err(Error::DeviceNotFound)
+    }
+
+    /// Connect to Jade on specific port
+    pub async fn connect_path(path: &str) -> Result<Self> {
+        debug!("Opening serial port: {path}");
+
+        let port = tokio_serial::new(path, SERIAL_BAUD_RATE)
+            .data_bits(tokio_serial::DataBits::Eight)
+            .stop_bits(tokio_serial::StopBits::One)
+            .parity(tokio_serial::Parity::None)
+            .flow_control(tokio_serial::FlowControl::None)
+            .open_native_async()?;
+
+        // Give device a moment to be ready
+        sleep(Duration::from_millis(500)).await;
+
+        Ok(Self {
+            port,
+            read_buffer: Vec::with_capacity(65536),
+        })
+    }
+
+    /// Find all potential Jade serial ports
+    pub fn find_jade_ports() -> Vec<tokio_serial::SerialPortInfo> {
+        let ports = tokio_serial::available_ports().unwrap_or_default();
+
+        ports
+            .into_iter()
+            .filter(|port| {
+                if let tokio_serial::SerialPortType::UsbPort(info) = &port.port_type {
+                    JADE_USB_IDS
+                        .iter()
+                        .any(|(vid, pid)| info.vid == *vid && info.pid == *pid)
+                } else {
+                    false
+                }
+            })
+            .collect()
+    }
+
+    /// List all available Jade devices
+    pub fn list_devices() -> Vec<String> {
+        Self::find_jade_ports()
+            .into_iter()
+            .map(|p| p.port_name)
+            .collect()
+    }
+
+    /// Send a request and receive response
+    pub async fn request(&mut self, request: &Request) -> Result<Response> {
+        self.send_request(request).await?;
+        self.receive_response().await
+    }
+
+    /// Send a CBOR-encoded request
+    pub async fn send_request(&mut self, request: &Request) -> Result<()> {
+        let cbor = serde_cbor::to_vec(request)?;
+        debug!("Sending request: {request:?}");
+        debug!("CBOR hex: {}", hex::encode(&cbor));
+
+        self.port.write_all(&cbor).await?;
+        self.port.flush().await?;
+
+        Ok(())
+    }
+
+    /// Receive and decode a CBOR response
+    pub async fn receive_response(&mut self) -> Result<Response> {
+        // Read CBOR message
+        // Jade sends complete CBOR messages, so we need to read until we have a complete one
+
+        debug!("Starting to receive response from Jade...");
+        self.read_buffer.clear();
+        let mut temp_buffer = [0u8; 4096];
+        let mut consecutive_empty_reads = 0;
+
+        // Read data until we have a complete CBOR message
+        loop {
+            // Use timeout for read operations
+            let read_result = timeout(
+                Duration::from_millis(SERIAL_TIMEOUT_MS),
+                self.port.read(&mut temp_buffer),
+            )
+            .await;
+
+            match read_result {
+                Ok(Ok(0)) => {
+                    // No data available right now
+                    consecutive_empty_reads += 1;
+
+                    // If we've had several empty reads and have data, try to parse it
+                    if consecutive_empty_reads > 3 && !self.read_buffer.is_empty() {
+                        match serde_cbor::from_slice::<Response>(&self.read_buffer) {
+                            Ok(response) => return Ok(response),
+                            Err(e) => {
+                                debug!(
+                                    "Failed to decode {} bytes after empty reads: {}",
+                                    self.read_buffer.len(),
+                                    e
+                                );
+                                // Give it more time
+                                sleep(Duration::from_millis(100)).await;
+                            }
+                        }
+                    }
+
+                    if consecutive_empty_reads > 10 {
+                        return Err(Error::Timeout);
+                    }
+
+                    // Small delay before retry
+                    sleep(Duration::from_millis(10)).await;
+                }
+                Ok(Ok(n)) => {
+                    // Got data
+                    consecutive_empty_reads = 0;
+                    self.read_buffer.extend_from_slice(&temp_buffer[..n]);
+
+                    // Try to decode CBOR
+                    match serde_cbor::from_slice::<Response>(&self.read_buffer) {
+                        Ok(response) => {
+                            debug!("Received response: {response:?}");
+                            debug!("Response hex: {}", hex::encode(&self.read_buffer));
+                            return Ok(response);
+                        }
+                        Err(e) => {
+                            // Check if this looks like a complete but invalid message
+                            if self.read_buffer.len() > 1000 {
+                                debug!(
+                                    "Failed to decode CBOR after {} bytes: {}",
+                                    self.read_buffer.len(),
+                                    e
+                                );
+                                debug!(
+                                    "Raw hex (first 200 bytes): {}",
+                                    hex::encode(
+                                        &self.read_buffer[..200.min(self.read_buffer.len())]
+                                    )
+                                );
+                                return Err(Error::InvalidResponse);
+                            }
+                            // Not enough data yet, continue reading
+                            continue;
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    return Err(Error::Io(e));
+                }
+                Err(_) => {
+                    // Timeout
+                    if !self.read_buffer.is_empty() {
+                        match serde_cbor::from_slice::<Response>(&self.read_buffer) {
+                            Ok(response) => return Ok(response),
+                            Err(decode_err) => {
+                                debug!(
+                                    "Timeout with {} bytes, decode error: {}",
+                                    self.read_buffer.len(),
+                                    decode_err
+                                );
+                            }
+                        }
+                    }
+                    return Err(Error::Timeout);
+                }
+            }
+        }
+    }
+}

--- a/jade-bitcoin/src/types.rs
+++ b/jade-bitcoin/src/types.rs
@@ -1,0 +1,79 @@
+//! Common types used throughout jade-bitcoin
+
+use serde::{Deserialize, Serialize};
+
+/// Bitcoin network type
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Network {
+    #[serde(rename = "mainnet")]
+    Bitcoin,
+    #[serde(rename = "testnet")]
+    Testnet,
+    #[serde(rename = "regtest")]
+    Regtest,
+    #[serde(rename = "signet")]
+    Signet,
+}
+
+impl Network {
+    /// Convert to string for Jade protocol
+    pub fn as_jade_str(&self) -> &str {
+        match self {
+            Network::Bitcoin => "mainnet",
+            Network::Testnet => "testnet",
+            Network::Regtest => "localtest",
+            Network::Signet => "testnet", // Jade treats signet as testnet
+        }
+    }
+
+    /// Convert to bitcoin crate network
+    pub fn to_bitcoin_network(&self) -> bitcoin::Network {
+        match self {
+            Network::Bitcoin => bitcoin::Network::Bitcoin,
+            Network::Testnet => bitcoin::Network::Testnet,
+            Network::Regtest => bitcoin::Network::Regtest,
+            Network::Signet => bitcoin::Network::Signet,
+        }
+    }
+}
+
+/// Device version information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionInfo {
+    #[serde(rename = "JADE_VERSION")]
+    pub jade_version: String,
+    #[serde(rename = "JADE_OTA_MAX_CHUNK")]
+    pub jade_ota_max_chunk: Option<u32>,
+    #[serde(rename = "JADE_CONFIG")]
+    pub jade_config: String,
+    #[serde(rename = "BOARD_TYPE")]
+    pub board_type: String,
+    #[serde(rename = "JADE_FEATURES")]
+    pub jade_features: String,
+    #[serde(rename = "IDF_VERSION")]
+    pub idf_version: String,
+    #[serde(rename = "CHIP_FEATURES")]
+    pub chip_features: String,
+    #[serde(rename = "EFUSEMAC")]
+    pub efusemac: String,
+    #[serde(rename = "BATTERY_STATUS")]
+    pub battery_status: Option<u32>,
+    #[serde(rename = "JADE_STATE")]
+    pub jade_state: String,
+    #[serde(rename = "JADE_NETWORKS")]
+    pub jade_networks: String,
+    #[serde(rename = "JADE_HAS_PIN")]
+    pub jade_has_pin: bool,
+}
+
+/// Device identifiers for auto-detection
+pub const JADE_USB_IDS: &[(u16, u16)] = &[
+    (0x10c4, 0xea60), // CP210x UART Bridge
+    (0x1a86, 0x55d4), // QinHeng CH9102F
+    (0x0403, 0x6001), // FTDI FT232
+];
+
+/// Default serial port settings
+pub const SERIAL_BAUD_RATE: u32 = 115200;
+pub const SERIAL_TIMEOUT_MS: u64 = 120000; // 120 seconds for PIN server auth


### PR DESCRIPTION
## Summary
- Adds complete Jade hardware wallet support with fully async serial communication
- Creates standalone `jade-bitcoin` crate that can be used independently
- Integrates Jade support into CyberKrill CLI

## Changes
- **New `jade-bitcoin` crate**: Standalone library for Jade hardware wallet communication
  - Async serial I/O using `tokio-serial` 
  - CBOR protocol implementation for device communication
  - PIN server authentication with HTTP proxy support
  - Support for all standard Bitcoin address types (P2PKH, P2SH-P2WPKH, P2WPKH)
  
- **CyberKrill CLI integration**: Three new commands
  - `jade-address`: Generate Bitcoin addresses from Jade
  - `jade-xpub`: Retrieve extended public keys
  - `jade-sign-psbt`: Sign PSBTs with Jade (implementation ready)

- **Authentication handling**:
  - Automatic PIN server authentication via blind oracle
  - Handles both locked and unlocked device states
  - Proxies HTTP requests between Jade and PIN server at https://jadepin.blockstream.com

## Technical Details
- Uses async/await throughout for non-blocking I/O
- Supports BIP32/44/49/84 derivation paths
- Network support: mainnet, testnet, regtest, signet
- Auto-detects Jade devices via USB vendor/product IDs
- Comprehensive error handling and logging

## Test Plan
- [x] Tested address generation for all supported types
- [x] Tested xpub retrieval
- [x] Tested PIN authentication flow with locked device
- [x] Tested with already unlocked device
- [x] Verified all async operations complete successfully

## Example Usage
```bash
# Generate native segwit address
cyberkrill jade-address --path "m/84'/0'/0'/0/0" --network mainnet

# Get extended public key
cyberkrill jade-xpub --path "m/84'/0'/0'" --network mainnet
```