### PR TITLE
refactor: reorganize commands with logical prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Powered by BDK (Bitcoin Development Kit) with multiple backend support:
 - **Descriptor Support**: Full output descriptor compatibility
 - **[frozenkrill](https://github.com/planktonlabs/frozenkrill) Integration**: Import wallet export files
 
+## Command Structure
+
+Commands are organized with logical prefixes for better clarity:
+- `ln-*` - Lightning Network operations
+- `fm-*` - Fedimint operations  
+- `hw-*` - Hardware wallet operations
+- `onchain-*` - Bitcoin onchain operations
+
 ## Installation
 
 ### Using Nix (Recommended)
@@ -86,13 +94,13 @@ cargo build --release
 
 ```bash
 # Decode a Lightning invoice
-cyberkrill decode-invoice lnbc1000n1pn...
+cyberkrill ln-decode-invoice lnbc1000n1pn...
 
 # Decode LNURL
-cyberkrill decode-lnurl lnurl1dp68gurn8ghj7mr0v...
+cyberkrill ln-decode-lnurl lnurl1dp68gurn8ghj7mr0v...
 
 # Generate invoice from Lightning address
-cyberkrill generate-invoice user@getalby.com 100000 --comment "Payment"
+cyberkrill ln-generate-invoice user@getalby.com 100000 --comment "Payment"
 ```
 
 ### Smartcard Operations (Tapsigner/Satscard)
@@ -100,26 +108,26 @@ cyberkrill generate-invoice user@getalby.com 100000 --comment "Payment"
 ```bash
 # Initialize Tapsigner (one-time setup)
 export TAPSIGNER_CVC=123456  # Your 6-digit PIN
-cyberkrill tapsigner-init
+cyberkrill hw-tapsigner-init
 
 # Generate Bitcoin address from Tapsigner
-cyberkrill tapsigner-address --path "m/84'/0'/0'/0/0"
+cyberkrill hw-tapsigner-address --path "m/84'/0'/0'/0/0"
 
 # Generate address from Satscard
-cyberkrill satscard-address --slot 1
+cyberkrill hw-satscard-address --slot 1
 ```
 
 ### Hardware Wallet Operations
 
 ```bash
 # Coldcard - Generate address
-cyberkrill coldcard-address --path "m/84'/0'/0'/0/0" --network mainnet
+cyberkrill hw-coldcard-address --path "m/84'/0'/0'/0/0" --network mainnet
 
 # Trezor - Get extended public key
-cyberkrill trezor-xpub --path "m/84'/0'/0'" --network mainnet
+cyberkrill hw-trezor-xpub --path "m/84'/0'/0'" --network mainnet
 
 # Jade - Generate address
-cyberkrill jade-address --path "m/84'/0'/0'/0/0" --network mainnet
+cyberkrill hw-jade-address --path "m/84'/0'/0'/0/0" --network mainnet
 ```
 
 ### Bitcoin UTXO Operations
@@ -127,14 +135,14 @@ cyberkrill jade-address --path "m/84'/0'/0'/0/0" --network mainnet
 ```bash
 # List UTXOs using different backends
 # Bitcoin Core (default)
-cyberkrill list-utxos --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)"
+cyberkrill onchain-list-utxos --descriptor "wpkh([fingerprint/84'/0'/0']xpub...)"
 
 # Electrum backend
-cyberkrill list-utxos --descriptor "wpkh([...]xpub...)" \
+cyberkrill onchain-list-utxos --descriptor "wpkh([...]xpub...)" \
   --electrum ssl://electrum.blockstream.info:50002
 
 # Esplora backend
-cyberkrill list-utxos --descriptor "wpkh([...]xpub...)" \
+cyberkrill onchain-list-utxos --descriptor "wpkh([...]xpub...)" \
   --esplora https://blockstream.info/api
 ```
 
@@ -142,18 +150,18 @@ cyberkrill list-utxos --descriptor "wpkh([...]xpub...)" \
 
 ```bash
 # Manual PSBT - Full control
-cyberkrill create-psbt \
+cyberkrill onchain-create-psbt \
   --inputs "txid:0" --inputs "txid:1" \
   --outputs "bc1qaddr:0.001" \
   --fee-rate 10sats
 
 # Funded PSBT - Automatic coin selection
-cyberkrill create-funded-psbt \
+cyberkrill onchain-create-funded-psbt \
   --outputs "bc1qaddr:0.001" \
   --fee-rate 15.5sats
 
 # UTXO Consolidation
-cyberkrill move-utxos \
+cyberkrill onchain-move-utxos \
   --inputs "txid:0" --inputs "txid:1" \
   --destination "bc1qconsolidated" \
   --fee-rate 5sats
@@ -165,10 +173,10 @@ cyberkrill move-utxos \
 
 ```bash
 # Using cookie authentication (recommended)
-cyberkrill list-utxos --bitcoin-dir ~/.bitcoin --descriptor "..."
+cyberkrill onchain-list-utxos --bitcoin-dir ~/.bitcoin --descriptor "..."
 
 # Using username/password
-cyberkrill list-utxos --rpc-user myuser --rpc-password mypass --descriptor "..."
+cyberkrill onchain-list-utxos --rpc-user myuser --rpc-password mypass --descriptor "..."
 ```
 
 ### Electrum
@@ -218,8 +226,8 @@ Full support for Bitcoin output descriptors:
 Import [frozenkrill](https://github.com/planktonlabs/frozenkrill) wallet export files instead of raw descriptors:
 
 ```bash
-cyberkrill list-utxos --wallet-file mywallet_pub.json
-cyberkrill create-funded-psbt --wallet-file mywallet_pub.json --outputs "bc1q...:0.001"
+cyberkrill onchain-list-utxos --wallet-file mywallet_pub.json
+cyberkrill onchain-create-funded-psbt --wallet-file mywallet_pub.json --outputs "bc1q...:0.001"
 ```
 
 ## Documentation

--- a/cyberkrill/src/main.rs
+++ b/cyberkrill/src/main.rs
@@ -21,40 +21,67 @@ enum Commands {
     LnDecodeInvoice(DecodeInvoiceArgs),
     #[command(name = "ln-decode-lnurl", about = "Decode LNURL string")]
     LnDecodeLnurl(DecodeLnurlArgs),
-    #[command(name = "ln-generate-invoice", about = "Generate invoice from Lightning address")]
+    #[command(
+        name = "ln-generate-invoice",
+        about = "Generate invoice from Lightning address"
+    )]
     LnGenerateInvoice(GenerateInvoiceArgs),
 
     // Fedimint Operations (fm-*)
     #[command(name = "fm-decode-invite", about = "Decode Fedimint invite code")]
     FmDecodeInvite(DecodeFedimintInviteArgs),
-    #[command(name = "fm-encode-invite", about = "Encode Fedimint invite code from JSON")]
+    #[command(
+        name = "fm-encode-invite",
+        about = "Encode Fedimint invite code from JSON"
+    )]
     FmEncodeInvite(EncodeFedimintInviteArgs),
-    #[command(name = "fm-fetch-config", about = "Fetch Fedimint federation configuration")]
+    #[command(
+        name = "fm-fetch-config",
+        about = "Fetch Fedimint federation configuration"
+    )]
     FmFetchConfig(FedimintConfigArgs),
 
     // Hardware Wallet Operations (hw-*)
     #[cfg(feature = "smartcards")]
-    #[command(name = "hw-tapsigner-address", about = "Generate Bitcoin address from Tapsigner")]
+    #[command(
+        name = "hw-tapsigner-address",
+        about = "Generate Bitcoin address from Tapsigner"
+    )]
     HwTapsignerAddress(TapsignerAddressArgs),
     #[cfg(feature = "smartcards")]
-    #[command(name = "hw-tapsigner-init", about = "Initialize Tapsigner (one-time setup)")]
+    #[command(
+        name = "hw-tapsigner-init",
+        about = "Initialize Tapsigner (one-time setup)"
+    )]
     HwTapsignerInit(TapsignerInitArgs),
     #[cfg(feature = "smartcards")]
-    #[command(name = "hw-satscard-address", about = "Generate Bitcoin address from Satscard")]
+    #[command(
+        name = "hw-satscard-address",
+        about = "Generate Bitcoin address from Satscard"
+    )]
     HwSatscardAddress(SatscardAddressArgs),
 
     // Coldcard Hardware Wallet Operations
     #[cfg(feature = "coldcard")]
-    #[command(name = "hw-coldcard-address", about = "Generate Bitcoin address from Coldcard")]
+    #[command(
+        name = "hw-coldcard-address",
+        about = "Generate Bitcoin address from Coldcard"
+    )]
     HwColdcardAddress(ColdcardAddressArgs),
     #[cfg(feature = "coldcard")]
     #[command(name = "hw-coldcard-sign-psbt", about = "Sign PSBT with Coldcard")]
     HwColdcardSignPsbt(ColdcardSignPsbtArgs),
     #[cfg(feature = "coldcard")]
-    #[command(name = "hw-coldcard-export-psbt", about = "Export PSBT to Coldcard SD card")]
+    #[command(
+        name = "hw-coldcard-export-psbt",
+        about = "Export PSBT to Coldcard SD card"
+    )]
     HwColdcardExportPsbt(ColdcardExportPsbtArgs),
     #[cfg(feature = "trezor")]
-    #[command(name = "hw-trezor-address", about = "Generate Bitcoin address from Trezor")]
+    #[command(
+        name = "hw-trezor-address",
+        about = "Generate Bitcoin address from Trezor"
+    )]
     HwTrezorAddress(TrezorAddressArgs),
     #[cfg(feature = "trezor")]
     #[command(name = "hw-trezor-sign-psbt", about = "Sign PSBT with Trezor")]
@@ -72,7 +99,10 @@ enum Commands {
     HwJadeSignPsbt(JadeSignPsbtArgs),
 
     // Bitcoin Onchain Operations (onchain-*)
-    #[command(name = "onchain-list-utxos", about = "List UTXOs for addresses or descriptors")]
+    #[command(
+        name = "onchain-list-utxos",
+        about = "List UTXOs for addresses or descriptors"
+    )]
     OnchainListUtxos(ListUtxosArgs),
     #[command(
         name = "onchain-create-psbt",
@@ -89,7 +119,10 @@ enum Commands {
         about = "Consolidate/move UTXOs to a single destination address (output = total inputs - fee)"
     )]
     OnchainMoveUtxos(MoveUtxosArgs),
-    #[command(name = "onchain-decode-psbt", about = "Decode a PSBT (Partially Signed Bitcoin Transaction)")]
+    #[command(
+        name = "onchain-decode-psbt",
+        about = "Decode a PSBT (Partially Signed Bitcoin Transaction)"
+    )]
     OnchainDecodePsbt(DecodePsbtArgs),
 }
 

--- a/cyberkrill/src/main.rs
+++ b/cyberkrill/src/main.rs
@@ -16,78 +16,81 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    // Lightning Network Operations
-    #[command(about = "Decode BOLT11 Lightning invoice")]
-    DecodeInvoice(DecodeInvoiceArgs),
-    #[command(about = "Decode LNURL string")]
-    DecodeLnurl(DecodeLnurlArgs),
-    #[command(about = "Generate invoice from Lightning address")]
-    GenerateInvoice(GenerateInvoiceArgs),
+    // Lightning Network Operations (ln-*)
+    #[command(name = "ln-decode-invoice", about = "Decode BOLT11 Lightning invoice")]
+    LnDecodeInvoice(DecodeInvoiceArgs),
+    #[command(name = "ln-decode-lnurl", about = "Decode LNURL string")]
+    LnDecodeLnurl(DecodeLnurlArgs),
+    #[command(name = "ln-generate-invoice", about = "Generate invoice from Lightning address")]
+    LnGenerateInvoice(GenerateInvoiceArgs),
 
-    // Fedimint Operations
-    #[command(about = "Decode Fedimint invite code")]
-    DecodeFedimintInvite(DecodeFedimintInviteArgs),
-    #[command(about = "Encode Fedimint invite code from JSON")]
-    EncodeFedimintInvite(EncodeFedimintInviteArgs),
-    #[command(about = "Fetch Fedimint federation configuration")]
-    FedimintConfig(FedimintConfigArgs),
+    // Fedimint Operations (fm-*)
+    #[command(name = "fm-decode-invite", about = "Decode Fedimint invite code")]
+    FmDecodeInvite(DecodeFedimintInviteArgs),
+    #[command(name = "fm-encode-invite", about = "Encode Fedimint invite code from JSON")]
+    FmEncodeInvite(EncodeFedimintInviteArgs),
+    #[command(name = "fm-fetch-config", about = "Fetch Fedimint federation configuration")]
+    FmFetchConfig(FedimintConfigArgs),
 
-    // Hardware Wallet Operations
+    // Hardware Wallet Operations (hw-*)
     #[cfg(feature = "smartcards")]
-    #[command(about = "Generate Bitcoin address from Tapsigner")]
-    TapsignerAddress(TapsignerAddressArgs),
+    #[command(name = "hw-tapsigner-address", about = "Generate Bitcoin address from Tapsigner")]
+    HwTapsignerAddress(TapsignerAddressArgs),
     #[cfg(feature = "smartcards")]
-    #[command(about = "Initialize Tapsigner (one-time setup)")]
-    TapsignerInit(TapsignerInitArgs),
+    #[command(name = "hw-tapsigner-init", about = "Initialize Tapsigner (one-time setup)")]
+    HwTapsignerInit(TapsignerInitArgs),
     #[cfg(feature = "smartcards")]
-    #[command(about = "Generate Bitcoin address from Satscard")]
-    SatscardAddress(SatscardAddressArgs),
+    #[command(name = "hw-satscard-address", about = "Generate Bitcoin address from Satscard")]
+    HwSatscardAddress(SatscardAddressArgs),
 
     // Coldcard Hardware Wallet Operations
     #[cfg(feature = "coldcard")]
-    #[command(about = "Generate Bitcoin address from Coldcard")]
-    ColdcardAddress(ColdcardAddressArgs),
+    #[command(name = "hw-coldcard-address", about = "Generate Bitcoin address from Coldcard")]
+    HwColdcardAddress(ColdcardAddressArgs),
     #[cfg(feature = "coldcard")]
-    #[command(about = "Sign PSBT with Coldcard")]
-    ColdcardSignPsbt(ColdcardSignPsbtArgs),
+    #[command(name = "hw-coldcard-sign-psbt", about = "Sign PSBT with Coldcard")]
+    HwColdcardSignPsbt(ColdcardSignPsbtArgs),
     #[cfg(feature = "coldcard")]
-    #[command(about = "Export PSBT to Coldcard SD card")]
-    ColdcardExportPsbt(ColdcardExportPsbtArgs),
+    #[command(name = "hw-coldcard-export-psbt", about = "Export PSBT to Coldcard SD card")]
+    HwColdcardExportPsbt(ColdcardExportPsbtArgs),
     #[cfg(feature = "trezor")]
-    #[command(about = "Generate Bitcoin address from Trezor")]
-    TrezorAddress(TrezorAddressArgs),
+    #[command(name = "hw-trezor-address", about = "Generate Bitcoin address from Trezor")]
+    HwTrezorAddress(TrezorAddressArgs),
     #[cfg(feature = "trezor")]
-    #[command(about = "Sign PSBT with Trezor")]
-    TrezorSignPsbt(TrezorSignPsbtArgs),
+    #[command(name = "hw-trezor-sign-psbt", about = "Sign PSBT with Trezor")]
+    HwTrezorSignPsbt(TrezorSignPsbtArgs),
 
     // Jade Hardware Wallet Operations
     #[cfg(feature = "jade")]
-    #[command(about = "Generate Bitcoin address from Jade")]
-    JadeAddress(JadeAddressArgs),
+    #[command(name = "hw-jade-address", about = "Generate Bitcoin address from Jade")]
+    HwJadeAddress(JadeAddressArgs),
     #[cfg(feature = "jade")]
-    #[command(about = "Get extended public key from Jade")]
-    JadeXpub(JadeXpubArgs),
+    #[command(name = "hw-jade-xpub", about = "Get extended public key from Jade")]
+    HwJadeXpub(JadeXpubArgs),
     #[cfg(feature = "jade")]
-    #[command(about = "Sign PSBT with Jade")]
-    JadeSignPsbt(JadeSignPsbtArgs),
+    #[command(name = "hw-jade-sign-psbt", about = "Sign PSBT with Jade")]
+    HwJadeSignPsbt(JadeSignPsbtArgs),
 
-    // Bitcoin RPC Operations
-    #[command(about = "List UTXOs for addresses or descriptors")]
-    ListUtxos(ListUtxosArgs),
+    // Bitcoin Onchain Operations (onchain-*)
+    #[command(name = "onchain-list-utxos", about = "List UTXOs for addresses or descriptors")]
+    OnchainListUtxos(ListUtxosArgs),
     #[command(
+        name = "onchain-create-psbt",
         about = "Create PSBT with manual input/output specification (you specify exact inputs, outputs, and change)"
     )]
-    CreatePsbt(CreatePsbtArgs),
+    OnchainCreatePsbt(CreatePsbtArgs),
     #[command(
+        name = "onchain-create-funded-psbt",
         about = "Create funded PSBT with automatic input selection and change output (wallet handles coin selection)"
     )]
-    CreateFundedPsbt(CreateFundedPsbtArgs),
+    OnchainCreateFundedPsbt(CreateFundedPsbtArgs),
     #[command(
+        name = "onchain-move-utxos",
         about = "Consolidate/move UTXOs to a single destination address (output = total inputs - fee)"
     )]
-    MoveUtxos(MoveUtxosArgs),
-    #[command(about = "Decode a PSBT (Partially Signed Bitcoin Transaction)")]
-    DecodePsbt(DecodePsbtArgs),
+    OnchainMoveUtxos(MoveUtxosArgs),
+    #[command(name = "onchain-decode-psbt", about = "Decode a PSBT (Partially Signed Bitcoin Transaction)")]
+    OnchainDecodePsbt(DecodePsbtArgs),
 }
 
 // Lightning Network Args
@@ -555,49 +558,49 @@ async fn main() -> anyhow::Result<()> {
     let args: Cli = Cli::parse();
     match args.command {
         // Lightning Network Operations
-        Commands::DecodeInvoice(args) => decode_invoice(args)?,
-        Commands::DecodeLnurl(args) => decode_lnurl(args)?,
-        Commands::GenerateInvoice(args) => generate_invoice(args).await?,
+        Commands::LnDecodeInvoice(args) => decode_invoice(args)?,
+        Commands::LnDecodeLnurl(args) => decode_lnurl(args)?,
+        Commands::LnGenerateInvoice(args) => generate_invoice(args).await?,
 
         // Fedimint Operations
-        Commands::DecodeFedimintInvite(args) => decode_fedimint_invite(args)?,
-        Commands::EncodeFedimintInvite(args) => encode_fedimint_invite(args)?,
-        Commands::FedimintConfig(args) => fedimint_config(args).await?,
+        Commands::FmDecodeInvite(args) => decode_fedimint_invite(args)?,
+        Commands::FmEncodeInvite(args) => encode_fedimint_invite(args)?,
+        Commands::FmFetchConfig(args) => fedimint_config(args).await?,
 
         // Hardware Wallet Operations
         #[cfg(feature = "smartcards")]
-        Commands::TapsignerAddress(args) => tapsigner_address(args).await?,
+        Commands::HwTapsignerAddress(args) => tapsigner_address(args).await?,
         #[cfg(feature = "smartcards")]
-        Commands::TapsignerInit(args) => tapsigner_init(args).await?,
+        Commands::HwTapsignerInit(args) => tapsigner_init(args).await?,
         #[cfg(feature = "smartcards")]
-        Commands::SatscardAddress(args) => satscard_address(args).await?,
+        Commands::HwSatscardAddress(args) => satscard_address(args).await?,
 
         // Coldcard Operations
         #[cfg(feature = "coldcard")]
-        Commands::ColdcardAddress(args) => coldcard_address(args).await?,
+        Commands::HwColdcardAddress(args) => coldcard_address(args).await?,
         #[cfg(feature = "coldcard")]
-        Commands::ColdcardSignPsbt(args) => coldcard_sign_psbt(args).await?,
+        Commands::HwColdcardSignPsbt(args) => coldcard_sign_psbt(args).await?,
         #[cfg(feature = "coldcard")]
-        Commands::ColdcardExportPsbt(args) => coldcard_export_psbt(args).await?,
+        Commands::HwColdcardExportPsbt(args) => coldcard_export_psbt(args).await?,
         #[cfg(feature = "trezor")]
-        Commands::TrezorAddress(args) => trezor_address(args).await?,
+        Commands::HwTrezorAddress(args) => trezor_address(args).await?,
         #[cfg(feature = "trezor")]
-        Commands::TrezorSignPsbt(args) => trezor_sign_psbt(args).await?,
+        Commands::HwTrezorSignPsbt(args) => trezor_sign_psbt(args).await?,
 
         // Jade Hardware Wallet Operations
         #[cfg(feature = "jade")]
-        Commands::JadeAddress(args) => jade_address(args).await?,
+        Commands::HwJadeAddress(args) => jade_address(args).await?,
         #[cfg(feature = "jade")]
-        Commands::JadeXpub(args) => jade_xpub(args).await?,
+        Commands::HwJadeXpub(args) => jade_xpub(args).await?,
         #[cfg(feature = "jade")]
-        Commands::JadeSignPsbt(args) => jade_sign_psbt(args).await?,
+        Commands::HwJadeSignPsbt(args) => jade_sign_psbt(args).await?,
 
-        // Bitcoin RPC Operations
-        Commands::ListUtxos(args) => bitcoin_list_utxos(args).await?,
-        Commands::CreatePsbt(args) => bitcoin_create_psbt(args).await?,
-        Commands::CreateFundedPsbt(args) => bitcoin_create_funded_psbt(args).await?,
-        Commands::MoveUtxos(args) => bitcoin_move_utxos(args).await?,
-        Commands::DecodePsbt(args) => decode_psbt(args)?,
+        // Bitcoin Onchain Operations
+        Commands::OnchainListUtxos(args) => bitcoin_list_utxos(args).await?,
+        Commands::OnchainCreatePsbt(args) => bitcoin_create_psbt(args).await?,
+        Commands::OnchainCreateFundedPsbt(args) => bitcoin_create_funded_psbt(args).await?,
+        Commands::OnchainMoveUtxos(args) => bitcoin_move_utxos(args).await?,
+        Commands::OnchainDecodePsbt(args) => decode_psbt(args)?,
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
Reorganize all CLI commands with logical prefixes for better clarity and organization. This is a **BREAKING CHANGE** - old command names are no longer supported.

## Changes

### 🎯 New Command Structure
Commands are now organized with clear prefixes:
- **`ln-*`** - Lightning Network operations (decode-invoice, decode-lnurl, generate-invoice)
- **`fm-*`** - Fedimint operations (decode-invite, encode-invite, fetch-config)
- **`hw-*`** - Hardware wallet operations (tapsigner, satscard, coldcard, trezor, jade)
- **`onchain-*`** - Bitcoin onchain operations (list-utxos, create-psbt, move-utxos, decode-psbt)

### ⚠️ Breaking Changes
- Old command names are **no longer supported**
- Users must update their scripts to use the new prefixed commands
- No backward compatibility aliases

### 📚 Documentation Updates
- README updated with new command structure
- All examples updated to use new command names
- Removed deprecated command references

## Migration Guide

### Before → After
```bash
# Lightning
decode-invoice        → ln-decode-invoice
decode-lnurl          → ln-decode-lnurl
generate-invoice      → ln-generate-invoice

# Fedimint
decode-fedimint-invite → fm-decode-invite
encode-fedimint-invite → fm-encode-invite
fedimint-config        → fm-fetch-config

# Hardware Wallets
tapsigner-init         → hw-tapsigner-init
tapsigner-address      → hw-tapsigner-address
satscard-address       → hw-satscard-address
coldcard-address       → hw-coldcard-address
trezor-address         → hw-trezor-address
jade-address           → hw-jade-address

# Bitcoin Onchain
list-utxos             → onchain-list-utxos
create-psbt            → onchain-create-psbt
create-funded-psbt     → onchain-create-funded-psbt
move-utxos             → onchain-move-utxos
decode-psbt            → onchain-decode-psbt
```

## Rationale
1. **Better Organization**: Commands are now logically grouped, making it easier to discover related functionality
2. **Clearer Intent**: Prefixes immediately tell users what domain they're working with
3. **Scalability**: As we add more commands, the prefix system keeps things organized
4. **Industry Standard**: Many CLI tools use this pattern (git, docker, kubectl, etc.)
5. **Clean Break**: No legacy baggage - new users get a clean, organized CLI from the start

## Testing
- [x] All commands compile successfully
- [x] Help output shows correct command names
- [x] Documentation updated with new names
- [x] No backward compatibility code remains