### PR TITLE
fix: correct gh release delete command syntax

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -287,12 +287,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Get the release ID if it exists
-        RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/latest-master --jq '.id' 2>/dev/null || echo "")
-        if [ -n "$RELEASE_ID" ]; then
-          echo "Deleting existing latest-master release..."
-          gh api -X DELETE repos/${{ github.repository }}/releases/$RELEASE_ID
-        fi
+        # Delete the release if it exists
+        gh release delete latest-master --yes 2>/dev/null || true
         
         # Delete the tag if it exists
         git push --delete origin latest-master 2>/dev/null || true


### PR DESCRIPTION
## Summary
Fixes the release workflow that was failing at the release creation step.

## Problem
The workflow was using incorrect `gh api` syntax which caused:
```
accepts 1 arg(s), received 2
```

## Solution
Replace complex gh api calls with simple `gh release delete` command that handles everything correctly.

## Testing
- Binaries are building successfully ✅
- Archives contain the correct files ✅
- Binary runs correctly when extracted ✅
- Just need to fix the release creation step

This will allow the automated releases to work properly on every master push.