### PR TITLE
fix: add write permissions for release creation

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -8,6 +8,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write  # Required for creating releases
+
 jobs:
   build-linux:
     name: Build Linux Binaries


### PR DESCRIPTION
## Summary
Fix the release workflow permissions to allow creating GitHub releases.

## Problem
The workflow was failing with:
```
HTTP 403: Resource not accessible by integration
```

This happens because GitHub Actions needs explicit permissions to create releases.

## Solution
Add `contents: write` permission to the workflow, which allows:
- Creating releases
- Uploading release assets
- Managing tags

## Status
- ✅ Binaries build successfully on all platforms
- ✅ Archives are created with correct structure
- ✅ Previous fix resolved the gh command syntax
- 🔧 This fix adds the required permissions

Once merged, the workflow will be able to create releases automatically.