### PR TITLE
refactor: simplify build configuration to all-or-nothing

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -40,33 +40,19 @@ jobs:
         restore-keys: |
           cargo-registry-${{ runner.os }}-
     
-    - name: Build x86_64 Linux (musl static - with smartcards)
+    - name: Build x86_64 Linux (full features)
       run: |
         nix develop -c cargo build --release
-        mkdir -p artifacts/linux-x86_64-musl
-        cp target/x86_64-unknown-linux-musl/release/cyberkrill artifacts/linux-x86_64-musl/cyberkrill
-        chmod +x artifacts/linux-x86_64-musl/cyberkrill
+        mkdir -p artifacts/linux-x86_64
+        cp target/x86_64-unknown-linux-musl/release/cyberkrill artifacts/linux-x86_64/cyberkrill
+        chmod +x artifacts/linux-x86_64/cyberkrill
         
-    - name: Build x86_64 Linux (musl static - no smartcards)
+    - name: Build x86_64 Linux (minimal)
       run: |
         nix develop -c cargo build --release --no-default-features
-        mkdir -p artifacts/linux-x86_64-musl-minimal
-        cp target/x86_64-unknown-linux-musl/release/cyberkrill artifacts/linux-x86_64-musl-minimal/cyberkrill
-        chmod +x artifacts/linux-x86_64-musl-minimal/cyberkrill
-    
-    - name: Build x86_64 Linux (glibc - full features)
-      run: |
-        nix develop -c cargo build --release --target x86_64-unknown-linux-gnu --features smartcards,coldcard,trezor,jade
-        mkdir -p artifacts/linux-x86_64-gnu
-        cp target/x86_64-unknown-linux-gnu/release/cyberkrill artifacts/linux-x86_64-gnu/cyberkrill
-        chmod +x artifacts/linux-x86_64-gnu/cyberkrill
-    
-    - name: Build using Nix flake (static binary)
-      run: |
-        nix build
-        mkdir -p artifacts/linux-x86_64-nix-static
-        cp result/bin/cyberkrill artifacts/linux-x86_64-nix-static/cyberkrill
-        chmod +x artifacts/linux-x86_64-nix-static/cyberkrill
+        mkdir -p artifacts/linux-x86_64-minimal
+        cp target/x86_64-unknown-linux-musl/release/cyberkrill artifacts/linux-x86_64-minimal/cyberkrill
+        chmod +x artifacts/linux-x86_64-minimal/cyberkrill
     
     - name: Create checksums
       run: |
@@ -245,10 +231,8 @@ jobs:
         ### Available Binaries
         
         #### Linux
-        - \`cyberkrill-linux-x86_64-musl.tar.gz\` - Static binary with smartcard support (works on all Linux distros)
-        - \`cyberkrill-linux-x86_64-musl-minimal.tar.gz\` - Static binary without smartcard support (smaller size)
-        - \`cyberkrill-linux-x86_64-gnu.tar.gz\` - Full features including all hardware wallets (requires glibc)
-        - \`cyberkrill-linux-x86_64-nix-static.tar.gz\` - Nix-built static binary
+        - \`cyberkrill-linux-x86_64.tar.gz\` - Static binary with all hardware wallet support (works on all Linux distros)
+        - \`cyberkrill-linux-x86_64-minimal.tar.gz\` - Static binary with core features only (smaller size)
         
         #### macOS
         - \`cyberkrill-macos-x86_64.tar.gz\` - Intel Mac binary
@@ -278,8 +262,8 @@ jobs:
         
         ### Features by Platform
         
-        - **Linux musl**: Smartcard support (Tapsigner/Satscard) when built with features
-        - **Linux GNU**: Full hardware wallet support (Coldcard, Trezor, Jade) 
+        - **Linux (full)**: All hardware wallets (Tapsigner, Satscard, Coldcard, Trezor, Jade)
+        - **Linux (minimal)**: Core functionality only
         - **macOS/Windows**: Core functionality (Lightning, Bitcoin, Fedimint operations)
         
         ---

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,19 +45,16 @@ jobs:
     - name: Run linting
       run: nix develop -c cargo clippy -- -D warnings
     
-    - name: Build default (musl with smartcards)
+    - name: Build default (all features)
       run: nix develop -c cargo build
     
-    - name: Build without smartcards
+    - name: Build minimal (no features)
       run: nix develop -c cargo build --no-default-features
     
-    - name: Build for native target with smartcards
-      run: nix develop -c cargo build --target x86_64-unknown-linux-gnu
-    
-    - name: Run tests (musl with smartcards)
+    - name: Run tests (all features)
       run: nix develop -c cargo test
     
-    - name: Run tests without smartcards
+    - name: Run tests minimal (no features)
       run: nix develop -c cargo test --no-default-features
     
     - name: Build with nix (static musl binary)

--- a/README.md
+++ b/README.md
@@ -71,23 +71,24 @@ Download the latest pre-built binaries from the [releases page](https://github.c
 
 | Platform | Variant | Features | Notes |
 |----------|---------|----------|-------|
-| Linux x86_64 | `musl` | Smartcards | Static binary, works on all distros |
-| Linux x86_64 | `musl-minimal` | Core only | Smaller static binary |
-| Linux x86_64 | `gnu` | All hardware wallets | Requires glibc, full features |
-| Linux x86_64 | `nix-static` | Core | Nix-built static binary |
-| macOS x86_64 | Standard | Core | Intel Macs |
-| macOS ARM64 | Standard | Core | Apple Silicon (M1/M2/M3) |
-| Windows x86_64 | Standard | Core | 64-bit Windows |
+| Linux x86_64 | Standard | All hardware wallets | Static binary, works on all distros |
+| Linux x86_64 | Minimal | Core only | Smaller static binary |
+| macOS x86_64 | Minimal | Core | Intel Macs |
+| macOS ARM64 | Minimal | Core | Apple Silicon (M1/M2/M3) |
+| Windows x86_64 | Minimal | Core | 64-bit Windows |
 
 #### Linux
 ```bash
-# Download the appropriate binary (example for x86_64 with smartcard support)
-wget https://github.com/douglaz/cyberkrill/releases/download/latest-master/cyberkrill-linux-x86_64-musl.tar.gz
+# Download the full-featured binary (all hardware wallets)
+wget https://github.com/douglaz/cyberkrill/releases/download/latest-master/cyberkrill-linux-x86_64.tar.gz
+
+# Or download the minimal binary (core features only)
+wget https://github.com/douglaz/cyberkrill/releases/download/latest-master/cyberkrill-linux-x86_64-minimal.tar.gz
 
 # Extract and install
-tar xzf cyberkrill-linux-x86_64-musl.tar.gz
-chmod +x cyberkrill-linux-x86_64-musl/cyberkrill
-sudo mv cyberkrill-linux-x86_64-musl/cyberkrill /usr/local/bin/
+tar xzf cyberkrill-linux-x86_64.tar.gz
+chmod +x cyberkrill-linux-x86_64/cyberkrill
+sudo mv cyberkrill-linux-x86_64/cyberkrill /usr/local/bin/
 
 # Verify installation
 cyberkrill --help
@@ -127,8 +128,11 @@ nix run .
 git clone https://github.com/douglaz/cyberkrill.git
 cd cyberkrill
 
-# Build with all features (recommended)
+# Build with all features (default)
 cargo build --release
+
+# Or build minimal version (core features only)
+cargo build --release --no-default-features
 
 # The binary will be at ./target/release/cyberkrill
 ./target/release/cyberkrill --help

--- a/cyberkrill-core/Cargo.toml
+++ b/cyberkrill-core/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["bitcoin", "lightning", "lnurl", "fedimint", "tapsigner"]
 categories = ["cryptography::cryptocurrencies"]
 
 [features]
-default = ["smartcards", "frozenkrill"]
+default = ["smartcards", "frozenkrill", "coldcard", "trezor", "jade"]
 smartcards = ["cktap-direct", "rusb"]
 frozenkrill = ["frozenkrill-core"]
 coldcard = ["dep:coldcard"]

--- a/cyberkrill/Cargo.toml
+++ b/cyberkrill/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/douglaz/cyberkrill"
 
 [features]
-default = ["smartcards", "frozenkrill"]
+default = ["smartcards", "frozenkrill", "coldcard", "trezor", "jade"]
 smartcards = ["cyberkrill-core/smartcards"]
 frozenkrill = ["cyberkrill-core/frozenkrill"]
 coldcard = ["cyberkrill-core/coldcard"]


### PR DESCRIPTION
## Summary
Simplify the build configuration to have only two options: everything or nothing.

## Changes

### Build Configuration
- **Default build**: Now includes ALL hardware wallet support (Tapsigner, Satscard, Coldcard, Trezor, Jade)
- **Minimal build**: Core features only with `--no-default-features`
- No more complex combinations - it's all or nothing

### CI/CD Simplification
- **Linux builds**: Reduced from 4 variants to 2 (full and minimal)
- **Removed variants**: No more separate musl/gnu/nix-static distinctions
- **Clearer naming**: "Standard" (full) vs "Minimal" in documentation

### Benefits
1. **Simpler for users**: Just two clear choices
2. **Faster CI**: Fewer build variants to compile and test
3. **Easier maintenance**: Less complexity in workflows
4. **Better defaults**: Most users want all features

### Technical Details
- Kept all existing feature names for code organization
- Features can still be individually controlled if needed
- Default Cargo.toml now includes: `["smartcards", "frozenkrill", "coldcard", "trezor", "jade"]`

## Testing
- [ ] Default build includes all hardware wallet commands
- [ ] Minimal build excludes hardware wallet commands
- [ ] CI passes with simplified workflows
- [ ] Binary artifacts are created correctly