### PR TITLE
fix: remove unused HardwareWallet trait to simplify codebase

### DIFF
--- a/cyberkrill-core/src/hardware_wallet.rs
+++ b/cyberkrill-core/src/hardware_wallet.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use bitcoin::{bip32::Xpub, Network};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -23,25 +22,6 @@ pub struct DeviceInfo {
     pub version: String,
     pub initialized: bool,
     pub fingerprint: Option<String>,
-}
-
-/// Common trait for all hardware wallet implementations
-#[async_trait::async_trait]
-pub trait HardwareWallet: Send + Sync {
-    /// Get device information
-    async fn get_device_info(&self) -> Result<DeviceInfo>;
-
-    /// Generate a Bitcoin address at the given derivation path
-    async fn get_address(&self, path: &str, network: Network) -> Result<AddressInfo>;
-
-    /// Get extended public key at the given derivation path
-    async fn get_xpub(&self, path: &str) -> Result<Xpub>;
-
-    /// Sign a PSBT (Partially Signed Bitcoin Transaction)
-    async fn sign_psbt(&self, psbt: &[u8]) -> Result<SignedPsbt>;
-
-    /// Check if the device is connected and responsive
-    async fn ping(&self) -> Result<bool>;
 }
 
 /// Helper function to parse and validate BIP32 derivation paths

--- a/flake.nix
+++ b/flake.nix
@@ -59,8 +59,8 @@
           LIBUSB_STATIC = "1";
           PKG_CONFIG_PATH = "${pkgs.pkgsStatic.libusb1}/lib/pkgconfig";
           
-          # Build with smartcards feature by default
-          buildFeatures = [ "smartcards" ];
+          # Don't specify features - use the defaults from Cargo.toml
+          # which includes all hardware wallets
           
           # Force cargo to use the musl target from .cargo/config.toml
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";
@@ -71,11 +71,10 @@
           buildPhase = ''
             runHook preBuild
             
-            echo "Building with musl target..."
+            echo "Building with musl target and default features (all hardware wallets)..."
             cargo build \
               --release \
               --target x86_64-unknown-linux-musl \
-              --features=smartcards \
               --offline \
               -j $NIX_BUILD_CORES
             
@@ -137,8 +136,8 @@
             libusb1
           ];
           
-          # Build with smartcards feature by default
-          buildFeatures = [ "smartcards" ];
+          # Use default features from Cargo.toml (all hardware wallets)
+          # No need to specify buildFeatures
           
           meta = with pkgs.lib; {
             description = "CLI utility for Bitcoin and Lightning Network operations (dynamic build)";

--- a/flake.nix
+++ b/flake.nix
@@ -63,14 +63,32 @@
           buildFeatures = [ "smartcards" ];
           
           # Force cargo to use the musl target from .cargo/config.toml
-          CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";
           CC_x86_64_unknown_linux_musl = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";
           CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static -C link-arg=-static";
           
-          # Override cargo target dir to use musl subdirectory
-          preBuild = ''
-            export CARGO_TARGET_DIR="target"
+          # Override buildPhase to use the correct target
+          buildPhase = ''
+            runHook preBuild
+            
+            echo "Building with musl target..."
+            cargo build \
+              --release \
+              --target x86_64-unknown-linux-musl \
+              --features=smartcards \
+              --offline \
+              -j $NIX_BUILD_CORES
+            
+            runHook postBuild
+          '';
+          
+          installPhase = ''
+            runHook preInstall
+            
+            mkdir -p $out/bin
+            cp target/x86_64-unknown-linux-musl/release/cyberkrill $out/bin/
+            
+            runHook postInstall
           '';
           
           # Ensure static linking


### PR DESCRIPTION
## Summary
Remove the unused HardwareWallet trait from hardware_wallet.rs to simplify the codebase.

## Changes
- Removed the async HardwareWallet trait that was never implemented by any hardware wallet
- Kept the shared data structures (AddressInfo, DeviceInfo, SignedPsbt) that are actively used
- Kept the parse_derivation_path() helper function used by implementations
- Removed unnecessary bitcoin and async_trait dependencies from the module

## Rationale
The trait was originally added for potential future abstraction but is not currently used. Each hardware wallet has its own unique interface and workflow that doesn't fit well into a common trait. Removing it simplifies the codebase without losing any functionality.