### PR TITLE
chore: improve string interpolation in jade-bitcoin examples

### DIFF
--- a/jade-bitcoin/examples/get_address.rs
+++ b/jade-bitcoin/examples/get_address.rs
@@ -43,19 +43,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Board type: {}", version.board_type);
 
     // Unlock the device
-    println!("\nUnlocking Jade for {:?}...", network);
+    println!("\nUnlocking Jade for {network:?}...");
     println!("Please check your Jade device and confirm the operation");
     jade.unlock(network).await?;
     println!("Jade unlocked");
 
     // Generate address
-    println!("\nGenerating address for path: {}", path);
+    println!("\nGenerating address for path: {path}");
     let address = jade.get_address(path, network).await?;
 
     println!("\n=== Bitcoin Address ===");
-    println!("Path:    {}", path);
-    println!("Network: {:?}", network);
-    println!("Address: {}", address);
+    println!("Path:    {path}");
+    println!("Network: {network:?}");
+    println!("Address: {address}");
 
     // Logout
     jade.logout().await?;

--- a/jade-bitcoin/examples/get_xpub.rs
+++ b/jade-bitcoin/examples/get_xpub.rs
@@ -28,12 +28,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Jade unlocked");
 
     // Get extended public key
-    println!("\nGetting xpub for path: {}", path);
+    println!("\nGetting xpub for path: {path}");
     let xpub = jade.get_xpub(path).await?;
 
     println!("\n=== Extended Public Key ===");
-    println!("Path: {}", path);
-    println!("xpub: {}", xpub);
+    println!("Path: {path}");
+    println!("xpub: {xpub}");
 
     // Demonstrate getting multiple xpubs
     println!("\n=== Additional xpubs ===");
@@ -48,11 +48,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let account_path = format!("m/{}'/{}'/{}'", purpose, 0, 0);
         match jade.get_xpub(&account_path).await {
             Ok(xpub) => {
-                println!("\n{} - {}", name, account_path);
-                println!("{}", xpub);
+                println!("\n{name} - {account_path}");
+                println!("{xpub}");
             }
             Err(e) => {
-                eprintln!("Failed to get xpub for {}: {}", account_path, e);
+                eprintln!("Failed to get xpub for {account_path}: {e}");
             }
         }
     }

--- a/jade-bitcoin/examples/get_xpub_quick.rs
+++ b/jade-bitcoin/examples/get_xpub_quick.rs
@@ -23,17 +23,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(_) => println!("Device unlocked"),
         Err(e) => {
             // If already unlocked, this might succeed anyway
-            println!("Note: {}", e);
+            println!("Note: {e}");
         }
     }
 
     // Get extended public key
-    println!("\nGetting xpub for path: {}", path);
+    println!("\nGetting xpub for path: {path}");
     let xpub = jade.get_xpub(path).await?;
 
     println!("\n=== Extended Public Key ===");
-    println!("Path: {}", path);
-    println!("xpub: {}", xpub);
+    println!("Path: {path}");
+    println!("xpub: {xpub}");
 
     Ok(())
 }

--- a/jade-bitcoin/examples/get_xpub_test.rs
+++ b/jade-bitcoin/examples/get_xpub_test.rs
@@ -18,10 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "regtest" => Network::Regtest,
         "signet" => Network::Signet,
         _ => {
-            eprintln!(
-                "Invalid network: {}. Use mainnet, testnet, regtest, or signet",
-                network_str
-            );
+            eprintln!("Invalid network: {network_str}. Use mainnet, testnet, regtest, or signet");
             return Ok(());
         }
     };
@@ -33,18 +30,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Connected to Jade");
 
     // Try to unlock for the specified network
-    println!("Unlocking device for {:?}...", network);
+    println!("Unlocking device for {network:?}...");
     jade.unlock(network).await?;
     println!("Device unlocked");
 
     // Get extended public key
-    println!("\nGetting xpub for path: {}", path);
+    println!("\nGetting xpub for path: {path}");
     let xpub = jade.get_xpub(path).await?;
 
     println!("\n=== Extended Public Key ===");
-    println!("Network: {:?}", network);
-    println!("Path: {}", path);
-    println!("xpub: {}", xpub);
+    println!("Network: {network:?}");
+    println!("Path: {path}");
+    println!("xpub: {xpub}");
 
     Ok(())
 }

--- a/jade-bitcoin/examples/sign_psbt.rs
+++ b/jade-bitcoin/examples/sign_psbt.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or(Network::Bitcoin);
 
     // Read PSBT file
-    println!("Reading PSBT from: {}", psbt_file);
+    println!("Reading PSBT from: {psbt_file}");
     let psbt_bytes = fs::read(psbt_file)?;
     println!("PSBT size: {} bytes", psbt_bytes.len());
 
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Jade version: {}", version.jade_version);
 
     // Unlock the device
-    println!("\nUnlocking Jade for {:?}...", network);
+    println!("\nUnlocking Jade for {network:?}...");
     println!("Please check your Jade device and confirm the operation");
     jade.unlock(network).await?;
     println!("Jade unlocked");
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Save signed PSBT
     let output_file = psbt_file.replace(".psbt", "_signed.psbt");
     fs::write(&output_file, signed_psbt)?;
-    println!("Signed PSBT saved to: {}", output_file);
+    println!("Signed PSBT saved to: {output_file}");
 
     // Logout
     jade.logout().await?;

--- a/jade-bitcoin/examples/test_simple.rs
+++ b/jade-bitcoin/examples/test_simple.rs
@@ -16,12 +16,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Try to get version
     println!("Getting version info...");
     let version = client.get_version_info().await?;
-    println!("Version: {:?}", version);
+    println!("Version: {version:?}");
 
     // Check if unlocked
     println!("Checking unlock status...");
     let unlocked = client.is_unlocked().await;
-    println!("Unlocked: {}", unlocked);
+    println!("Unlocked: {unlocked}");
 
     if !unlocked {
         println!("Device is locked. Attempting to unlock for mainnet...");
@@ -32,7 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Try to get xpub
     println!("Getting xpub...");
     let xpub = client.get_xpub("m/84'/0'/0'").await?;
-    println!("xpub: {}", xpub);
+    println!("xpub: {xpub}");
 
     println!("Test completed successfully!");
     Ok(())

--- a/jade-bitcoin/examples/test_unlock.rs
+++ b/jade-bitcoin/examples/test_unlock.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("✓ Device unlocked successfully!");
             }
             Err(e) => {
-                println!("✗ Failed to unlock: {}", e);
+                println!("✗ Failed to unlock: {e}");
                 return Err(e.into());
             }
         }
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("✓ Got xpub: {}", &xpub[..20]);
         }
         Err(e) => {
-            println!("✗ Failed to get xpub: {}", e);
+            println!("✗ Failed to get xpub: {e}");
         }
     }
 

--- a/jade-bitcoin/examples/test_version.rs
+++ b/jade-bitcoin/examples/test_version.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Has PIN: {}", version.jade_has_pin);
         }
         Err(e) => {
-            eprintln!("Failed to get version info: {}", e);
+            eprintln!("Failed to get version info: {e}");
         }
     }
 

--- a/jade-bitcoin/tests/integration.rs
+++ b/jade-bitcoin/tests/integration.rs
@@ -86,6 +86,6 @@ mod unit_tests {
         // This should work even without a device
         let devices = JadeClient::list_devices();
         // Just ensure it doesn't panic
-        println!("Device list returned: {:?}", devices);
+        println!("Device list returned: {devices:?}");
     }
 }


### PR DESCRIPTION
## Summary
Improve string interpolation in jade-bitcoin example files to follow project conventions outlined in CONVENTIONS.md.

## Changes
- Replace positional format arguments (`{}`) with named variables where applicable
- Use direct variable interpolation for cleaner, more readable code (e.g., `{path}` instead of `{}` with path argument)
- Consistent formatting across all jade-bitcoin examples and tests

## Files Modified
- `jade-bitcoin/examples/get_address.rs`
- `jade-bitcoin/examples/get_xpub.rs`
- `jade-bitcoin/examples/get_xpub_quick.rs`
- `jade-bitcoin/examples/get_xpub_test.rs`
- `jade-bitcoin/examples/sign_psbt.rs`
- `jade-bitcoin/examples/test_simple.rs`
- `jade-bitcoin/examples/test_unlock.rs`
- `jade-bitcoin/examples/test_version.rs`
- `jade-bitcoin/tests/integration.rs`

## Type of Change
- [x] Code style/formatting improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
These are formatting-only changes with no functional impact. All examples continue to work as expected.

## Notes
This is a cleanup PR separate from feature work to maintain clean, focused commits as per project guidelines.