### PR TITLE
feat: add version support and bootstrap script with CI integration

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -218,6 +218,11 @@ jobs:
         mv release-artifacts/cyberkrill-linux-binaries/* release-files/
         mv release-artifacts/cyberkrill-macos-binaries/* release-files/
         mv release-artifacts/cyberkrill-windows-binaries/* release-files/
+        
+        # Add the bootstrap script
+        cp cyberkrill.sh release-files/
+        chmod +x release-files/cyberkrill.sh
+        
         ls -la release-files/
     
     - name: Create release notes
@@ -242,6 +247,24 @@ jobs:
         - \`cyberkrill-windows-x86_64.zip\` - Windows 64-bit executable
         
         ### Installation
+        
+        #### Quick Install (Using Bootstrap Script)
+        
+        Download and use \`cyberkrill.sh\` for automatic installation and updates:
+        
+        \`\`\`bash
+        curl -L https://github.com/douglaz/cyberkrill/releases/download/latest-master/cyberkrill.sh -o cyberkrill.sh
+        chmod +x cyberkrill.sh
+        ./cyberkrill.sh --help
+        \`\`\`
+        
+        The bootstrap script will:
+        - Automatically detect your platform
+        - Download the appropriate binary
+        - Extract and install to \`~/.local/bin\`
+        - Use local builds when available (for development)
+        
+        #### Manual Installation
         
         1. Download the appropriate binary for your platform
         2. Extract the archive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "cyberkrill"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "cyberkrill-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cyberkrill-core/Cargo.toml
+++ b/cyberkrill-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cyberkrill-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Core functionality for Bitcoin and Lightning Network operations"
 license = "MIT"

--- a/cyberkrill/Cargo.toml
+++ b/cyberkrill/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cyberkrill"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "CLI utility for Bitcoin and Lightning Network operations"
 license = "MIT"

--- a/cyberkrill/src/main.rs
+++ b/cyberkrill/src/main.rs
@@ -8,6 +8,7 @@ const DEFAULT_BITCOIN_RPC_URL: &str = "http://127.0.0.1:8332";
 
 #[derive(Parser)]
 #[command(name = "cyberkrill")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(about = "A CLI toolkit for Bitcoin and Lightning Network operations")]
 struct Cli {
     #[clap(subcommand)]
@@ -129,6 +130,10 @@ enum Commands {
         about = "Generate DCA (Dollar Cost Averaging) report for UTXOs"
     )]
     OnchainDcaReport(DcaReportArgs),
+    
+    // Utility Commands
+    #[command(name = "version", about = "Print version information")]
+    Version,
 }
 
 // Lightning Network Args
@@ -671,6 +676,11 @@ async fn main() -> anyhow::Result<()> {
         Commands::OnchainMoveUtxos(args) => bitcoin_move_utxos(args).await?,
         Commands::OnchainDecodePsbt(args) => decode_psbt(args)?,
         Commands::OnchainDcaReport(args) => dca_report(args).await?,
+        
+        // Utility Commands
+        Commands::Version => {
+            println!("cyberkrill {}", env!("CARGO_PKG_VERSION"));
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

This PR adds version support to cyberkrill and introduces a bootstrap script for easy installation and updates, integrated with the CI/CD pipeline.

## Changes

### Version Support
- Updated version to 0.2.0 in both `cyberkrill` and `cyberkrill-core` Cargo.toml files
- Added `--version` flag support using clap's built-in version handling
- Added `version` subcommand for explicit version checking

### Bootstrap Script (`cyberkrill.sh`)
- Automatic platform detection (Linux x86_64/aarch64, macOS Intel/ARM, Windows)
- Downloads binaries from GitHub releases (`latest-master` pre-release)
- Extracts tar.gz (Unix) and zip (Windows) archives
- Installs to `~/.local/bin` with version tracking
- Prioritizes local builds when available (for development)
- Caches downloads and checks for updates once per day

### CI Integration
- Updated `release-binaries.yml` to include `cyberkrill.sh` in release artifacts
- Enhanced release notes with bootstrap script installation instructions
- Maintains backward compatibility with manual installation

## Test Plan
- [x] Bootstrap script successfully downloads from GitHub releases
- [x] Archive extraction works correctly for tar.gz files
- [x] Local builds are prioritized when available
- [x] Version commands (`--version` and `version`) work correctly
- [x] CI workflow updated to include bootstrap script

## Breaking Changes
None - all changes are additive and backward compatible.

## Installation

Users can now install cyberkrill with a single command:
```bash
curl -L https://github.com/douglaz/cyberkrill/releases/download/latest-master/cyberkrill.sh -o cyberkrill.sh
chmod +x cyberkrill.sh
./cyberkrill.sh --help
```