### PR TITLE
fix(wrapper): handle BASH_SOURCE unavailability when script is piped through stdin

### DIFF
--- a/cyberkrill.sh
+++ b/cyberkrill.sh
@@ -6,7 +6,12 @@ REPO="douglaz/cyberkrill"
 BINARY_NAME="cyberkrill"
 INSTALL_DIR="${HOME}/.local/bin"
 INSTALLED_VERSION_FILE="${INSTALL_DIR}/.${BINARY_NAME}.version"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Determine script directory (only available when run as a file, not via stdin)
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+    SCRIPT_DIR=""
+fi
 
 # Platform detection
 detect_platform() {
@@ -166,7 +171,7 @@ should_check_update() {
 # Main logic
 main() {
     # First, check if we're in the repository and can run locally
-    if [[ -d "${SCRIPT_DIR}/.git" ]]; then
+    if [[ -n "$SCRIPT_DIR" && -d "${SCRIPT_DIR}/.git" ]]; then
         # Check if we have a local build
         local local_binary="${SCRIPT_DIR}/target/release/${BINARY_NAME}"
         if [[ ! -f "$local_binary" ]]; then


### PR DESCRIPTION
## Summary
Fixes the wrapper script to work when piped through stdin (e.g., `curl ... | bash`)

## Problem
The wrapper script was failing with the error:
```
bash: line 9: BASH_SOURCE[0]: unbound variable
bash: line 9: cd: null directory
```

This occurred when users tried to run the quick install command:
```bash
curl -sSfL https://raw.githubusercontent.com/douglaz/cyberkrill/master/cyberkrill.sh | bash -s -- --help
```

## Root Cause
- `BASH_SOURCE[0]` is not available when a script is executed via stdin
- The script uses `set -u` which makes undefined variables fatal
- Line 9 tried to use `BASH_SOURCE[0]` unconditionally to determine the script directory

## Solution
Added conditional handling for `BASH_SOURCE` availability:
1. When script is run as a file: Uses `BASH_SOURCE` to find script directory (for local builds)
2. When piped through stdin: Sets `SCRIPT_DIR` to empty string and skips local build detection

## Changes
- Added conditional check for `BASH_SOURCE[0]` availability
- Set `SCRIPT_DIR` to empty string when running via stdin
- Updated directory checks to handle empty `SCRIPT_DIR`

## Test Plan
- [x] Tested piped execution: `cat cyberkrill.sh | bash -s -- --help` ✅
- [x] Tested direct execution: `./cyberkrill.sh --help` ✅
- [x] Both modes work correctly without errors