### PR TITLE
chore(deps): upgrade dependencies and add cargo-edit to dev environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2076,7 +2076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2964,7 +2964,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3134,7 +3134,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes 0.13.0",
  "rand 0.8.5",
  "secp256k1-sys",
  "serde",
@@ -3777,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "trezor-client"
 version = "0.1.5"
-source = "git+https://github.com/trezor/trezor-firmware#e3fcde178a4588696bcf90243e10855e9625ac30"
+source = "git+https://github.com/trezor/trezor-firmware#0e72c2178cd24750deeda1b4264933946285bcc7"
 dependencies = [
  "bitcoin",
  "byteorder",
@@ -4054,11 +4054,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/cyberkrill-core/Cargo.toml
+++ b/cyberkrill-core/Cargo.toml
@@ -17,18 +17,18 @@ trezor = ["dep:trezor-client", "rusb"]
 jade = ["dep:jade-bitcoin"]
 
 [dependencies]
-anyhow = { version = "1.0.95", features = ["backtrace"] }
+anyhow = { version = "1.0.99", features = ["backtrace"] }
 thiserror = "1.0"
 async-trait = "0.1"
 hex = { version = "0.4.3", features = ["serde"] }
-lightning-invoice = { version = "0.33.1", features = ["serde"] }
-serde = { version = "1.0.217", features = ["derive"] }
-serde_json = "1.0.138"
+lightning-invoice = { version = "0.33.2", features = ["serde"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
 bech32 = "0.9.1"
 base64 = "0.22"
-url = "2.5.0"
+url = "2.5.4"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.47", features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
 fedimint-lite = { path = "../fedimint-lite" }
 tracing = "0.1"
@@ -40,9 +40,9 @@ secp256k1 = "0.29"
 rand = "0.8"
 sha2 = "0.10"
 # BDK wallet support
-bdk_wallet = "2.0.0"
-bdk_electrum = { version = "0.23.0", default-features = false, features = ["use-rustls"] }
-bdk_esplora = { version = "0.22.0", default-features = false, features = ["blocking", "blocking-https-rustls"] }
+bdk_wallet = "2.1.0"
+bdk_electrum = { version = "0.23.1", default-features = false, features = ["use-rustls"] }
+bdk_esplora = { version = "0.22.1", default-features = false, features = ["blocking", "blocking-https-rustls"] }
 # frozenkrill support
 frozenkrill-core = { git = "https://github.com/planktonlabs/frozenkrill", optional = true }
 # Coldcard hardware wallet support
@@ -53,6 +53,6 @@ trezor-client = { git = "https://github.com/trezor/trezor-firmware", package = "
 jade-bitcoin = { path = "../jade-bitcoin", optional = true }
 
 [dev-dependencies]
-tempfile = "3.0"
-mockito = "1.0"
-serial_test = "3.0"
+tempfile = "3.20"
+mockito = "1.7"
+serial_test = "3.2"

--- a/cyberkrill/Cargo.toml
+++ b/cyberkrill/Cargo.toml
@@ -15,10 +15,10 @@ trezor = ["cyberkrill-core/trezor"]
 jade = ["cyberkrill-core/jade"]
 
 [dependencies]
-anyhow = { version = "1.0.95", features = ["backtrace"] }
-clap = { version = "4.5.28", features = ["derive", "env"] }
-serde_json = "1.0.138"
-tokio = { version = "1.0", features = ["full"] }
+anyhow = { version = "1.0.99", features = ["backtrace"] }
+clap = { version = "4.5.45", features = ["derive", "env"] }
+serde_json = "1.0.143"
+tokio = { version = "1.47", features = ["full"] }
 cyberkrill-core = { path = "../cyberkrill-core", default-features = false }
 fedimint-lite = { path = "../fedimint-lite" }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
@@ -34,4 +34,4 @@ bitcoin = "0.32"
 
 [dev-dependencies]
 rmcp = { version = "0.5", features = ["server", "client", "transport-child-process"] }
-tokio = { version = "1.0", features = ["full", "test-util", "process"] }
+tokio = { version = "1.47", features = ["full", "test-util", "process"] }

--- a/fedimint-lite/Cargo.toml
+++ b/fedimint-lite/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["rt", "macros"] }
+tokio = { version = "1.47", features = ["rt", "macros"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,7 @@
             libusb1
             pkgsStatic.libusb1
             gh
+            cargo-edit
           ];
 
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
               "frozenkrill-core-0.0.0" = "sha256-NK4ghVnX9hp6GX1V9arWlEZ+6U/DR5jaZsOPxTTyhw4=";
               "coldcard-0.12.2" = "sha256-S+MARrWsdGCsfe4A3cUqaKSijo81MfH6KLIeuBpMckc=";
               "hidapi-compat-0.1.0" = "sha256-WqRo+VYAOZmhT++VCPkU/YYjlZJvUCF1H+nC5+iQ8Vc=";
-              "trezor-client-0.1.5" = "sha256-PK7tfg94PFbfFEmR2polUNVq5yhwrfS1iF8Wm71HpfE=";
+              "trezor-client-0.1.5" = "sha256-lZkB53ykCTlUue2J1jICKky58LpaSFc+fSNzRYOMPFw=";
             };
           };
           
@@ -123,7 +123,7 @@
               "frozenkrill-core-0.0.0" = "sha256-NK4ghVnX9hp6GX1V9arWlEZ+6U/DR5jaZsOPxTTyhw4=";
               "coldcard-0.12.2" = "sha256-S+MARrWsdGCsfe4A3cUqaKSijo81MfH6KLIeuBpMckc=";
               "hidapi-compat-0.1.0" = "sha256-WqRo+VYAOZmhT++VCPkU/YYjlZJvUCF1H+nC5+iQ8Vc=";
-              "trezor-client-0.1.5" = "sha256-PK7tfg94PFbfFEmR2polUNVq5yhwrfS1iF8Wm71HpfE=";
+              "trezor-client-0.1.5" = "sha256-lZkB53ykCTlUue2J1jICKky58LpaSFc+fSNzRYOMPFw=";
             };
           };
           


### PR DESCRIPTION
## Summary
This PR upgrades all compatible dependencies to their latest versions and adds cargo-edit to the nix development environment for easier dependency management in the future.

## Changes

### Dependency Upgrades
- `anyhow`: 1.0.95 → 1.0.99
- `clap`: 4.5.28 → 4.5.45
- `serde`: 1.0.217 → 1.0.219
- `serde_json`: 1.0.138 → 1.0.143
- `tokio`: 1.0 → 1.47
- `url`: 2.5.0 → 2.5.4
- `lightning-invoice`: 0.33.1 → 0.33.2
- `bdk_wallet`: 2.0.0 → 2.1.0
- `bdk_electrum`: 0.23.0 → 0.23.1
- `bdk_esplora`: 0.22.0 → 0.22.1
- `tempfile`: 3.0 → 3.20
- `mockito`: 1.0 → 1.7
- `serial_test`: 3.0 → 3.2

### Development Environment
- Added `cargo-edit` to the nix flake development shell
- This enables commands like `cargo upgrade`, `cargo add`, and `cargo rm` for easier dependency management

## Test Plan
- [x] All 123 tests passing
- [x] No clippy warnings
- [x] Code properly formatted
- [x] Pre-push hooks passed