### PR TITLE
chore(ci): remove Magic Nix Cache to evaluate performance impact

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -26,9 +26,6 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
     
-    - name: Setup Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
-    
     - name: Cache Cargo registry
       uses: actions/cache@v4
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,9 +24,6 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
     
-    - name: Setup Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
-    
     # Only cache cargo registry (dependencies), not target directory
     # Target caching conflicts with nix environment and multiple build targets
     - name: Cache Cargo registry

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -81,9 +81,6 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
 
-    - name: Setup Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
-
     - name: Build for CodeQL
       run: nix develop -c cargo build --release
 


### PR DESCRIPTION
## Summary
Removing the Magic Nix Cache from CI workflows to evaluate its performance impact on build times.

## Changes
- Remove `DeterminateSystems/magic-nix-cache-action` from all workflow files
- Keep `cachix/install-nix-action` for Nix installation
- Retain cargo registry cache for dependency caching

## Motivation
Testing whether the Magic Nix Cache speeds up or slows down CI builds. This will help determine the optimal caching strategy for the project.

## Test Plan
- [x] All workflow files updated
- [ ] Monitor CI build times after merge
- [ ] Compare with previous build times to evaluate impact

## Impact
No functional changes to the codebase. Only affects CI build performance.