### PR TITLE
chore: add result symlink to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.local.*
+result


### PR DESCRIPTION
The 'result' symlink is created by 'nix build' and should not be tracked in version control. This PR adds it to .gitignore to prevent it from being accidentally committed in the future.