### PR TITLE
refactor: clean up bech32 0.11 migration code

### DIFF
--- a/cyberkrill-core/src/decoder.rs
+++ b/cyberkrill-core/src/decoder.rs
@@ -161,14 +161,12 @@ pub fn decode_lnurl(input: &str) -> Result<LnurlOutput> {
 
     let (hrp, data) = bech32::decode(input)?;
     anyhow::ensure!(
-        hrp.as_str().to_lowercase() == "lnurl",
+        hrp == bech32::primitives::hrp::Hrp::parse("lnurl")?,
         "Invalid HRP (human-readable part): expected 'lnurl', got '{}'",
         hrp.as_str()
     );
 
-    // The bech32::decode function now returns Vec<u8> directly
-    let decoded_bytes = data;
-    let url_str = String::from_utf8(decoded_bytes)?;
+    let url_str = String::from_utf8(data)?;
 
     let url = Url::parse(&url_str)?;
     let mut query_params = HashMap::new();

--- a/fedimint-lite/src/lib.rs
+++ b/fedimint-lite/src/lib.rs
@@ -75,7 +75,7 @@ fn decode_bech32m_invite(input: &str) -> Result<FedimintInviteOutput> {
     // Verify HRP
     let hrp = checked.hrp();
     anyhow::ensure!(
-        hrp.as_str() == "fed1",
+        hrp == bech32::primitives::hrp::Hrp::parse("fed1")?,
         "Invalid HRP (human-readable part): expected 'fed1', got '{}'",
         hrp.as_str()
     );

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/xmh41nb7ln05zm1ifcfvsn9wb6vsl6j4-cyberkrill-0.1.0


### PR DESCRIPTION
## Summary
Follow-up to #83 to clean up the bech32 0.11 migration code based on review feedback.

## Changes
- Remove unnecessary intermediate variable `decoded_bytes = data` in decoder.rs
- Use direct HRP comparison leveraging bech32's built-in case-insensitive equality
- Replace `hrp.as_str() == "string"` patterns with `hrp == Hrp::parse("string")?`

## Benefits
- Cleaner, more idiomatic code
- Better use of the bech32 library's built-in functionality
- Proper error handling with `?` operator instead of string comparisons
- Removes redundant variable assignment

All tests pass ✅