### PR TITLE
chore: update Rust edition to 2024

### DIFF
--- a/cyberkrill-core/Cargo.toml
+++ b/cyberkrill-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cyberkrill-core"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 description = "Core functionality for Bitcoin and Lightning Network operations"
 license = "MIT"
 repository = "https://github.com/douglaz/cyberkrill"

--- a/cyberkrill-core/src/bdk_wallet.rs
+++ b/cyberkrill-core/src/bdk_wallet.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use base64::Engine;
 use bdk_wallet::{KeychainKind, Wallet};
 use bitcoin::{Amount, FeeRate, Network, OutPoint, Txid};
@@ -129,7 +129,7 @@ pub async fn scan_and_list_utxos_electrum(
     electrum_url: &str,
     stop_gap: u32,
 ) -> Result<Vec<BdkUtxo>> {
-    use bdk_electrum::{electrum_client, BdkElectrumClient};
+    use bdk_electrum::{BdkElectrumClient, electrum_client};
 
     let descriptors = expand_multipath_descriptor(descriptor);
     let mut all_utxos = Vec::new();
@@ -306,7 +306,7 @@ pub async fn scan_and_list_utxos_esplora(
     esplora_url: &str,
     stop_gap: u32,
 ) -> Result<Vec<BdkUtxo>> {
-    use bdk_esplora::{esplora_client, EsploraExt};
+    use bdk_esplora::{EsploraExt, esplora_client};
 
     let descriptors = expand_multipath_descriptor(descriptor);
     let mut all_utxos = Vec::new();
@@ -490,7 +490,7 @@ pub async fn create_psbt_bdk(
     // Sync wallet with blockchain and get UTXOs
     let utxos = if backend.starts_with("electrum://") {
         let url = backend.strip_prefix("electrum://").unwrap();
-        use bdk_electrum::{electrum_client, BdkElectrumClient};
+        use bdk_electrum::{BdkElectrumClient, electrum_client};
 
         let client = BdkElectrumClient::new(
             electrum_client::Client::new(url).context("Failed to create Electrum client")?,
@@ -524,7 +524,7 @@ pub async fn create_psbt_bdk(
         utxos
     } else if backend.starts_with("esplora://") {
         let url = backend.strip_prefix("esplora://").unwrap();
-        use bdk_esplora::{esplora_client, EsploraExt};
+        use bdk_esplora::{EsploraExt, esplora_client};
 
         let client = esplora_client::Builder::new(url).build_blocking();
         let request = wallet.start_full_scan().build();
@@ -656,7 +656,7 @@ pub async fn create_funded_psbt_bdk(
     // Sync wallet with blockchain
     if backend.starts_with("electrum://") {
         let url = backend.strip_prefix("electrum://").unwrap();
-        use bdk_electrum::{electrum_client, BdkElectrumClient};
+        use bdk_electrum::{BdkElectrumClient, electrum_client};
 
         let client = BdkElectrumClient::new(
             electrum_client::Client::new(url).context("Failed to create Electrum client")?,
@@ -667,7 +667,7 @@ pub async fn create_funded_psbt_bdk(
         wallet.apply_update(update)?;
     } else if backend.starts_with("esplora://") {
         let url = backend.strip_prefix("esplora://").unwrap();
-        use bdk_esplora::{esplora_client, EsploraExt};
+        use bdk_esplora::{EsploraExt, esplora_client};
 
         let client = esplora_client::Builder::new(url).build_blocking();
         let request = wallet.start_full_scan().build();
@@ -752,7 +752,7 @@ pub async fn move_utxos_bdk(
     // Sync wallet with blockchain and get UTXOs
     let utxos = if backend.starts_with("electrum://") {
         let url = backend.strip_prefix("electrum://").unwrap();
-        use bdk_electrum::{electrum_client, BdkElectrumClient};
+        use bdk_electrum::{BdkElectrumClient, electrum_client};
 
         let client = BdkElectrumClient::new(
             electrum_client::Client::new(url).context("Failed to create Electrum client")?,
@@ -786,7 +786,7 @@ pub async fn move_utxos_bdk(
         utxos
     } else if backend.starts_with("esplora://") {
         let url = backend.strip_prefix("esplora://").unwrap();
-        use bdk_esplora::{esplora_client, EsploraExt};
+        use bdk_esplora::{EsploraExt, esplora_client};
 
         let client = esplora_client::Builder::new(url).build_blocking();
         let request = wallet.start_full_scan().build();

--- a/cyberkrill-core/src/bitcoin_rpc.rs
+++ b/cyberkrill-core/src/bitcoin_rpc.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use bitcoin::psbt::Psbt;
-use bitcoin::transaction::{predict_weight, InputWeightPrediction};
+use bitcoin::transaction::{InputWeightPrediction, predict_weight};
 use bitcoin::{Amount, Weight};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -962,7 +962,7 @@ impl BitcoinRpcClient {
     /// Returns the parsed PSBT if valid, error if invalid
     fn validate_psbt(psbt_str: &str) -> Result<Psbt> {
         // Decode base64 string to bytes first
-        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        use base64::{Engine as _, engine::general_purpose::STANDARD};
         let psbt_bytes = STANDARD
             .decode(psbt_str)
             .with_context(|| "Failed to decode base64 PSBT string")?;

--- a/cyberkrill-core/src/bitcoin_rpc.rs
+++ b/cyberkrill-core/src/bitcoin_rpc.rs
@@ -394,10 +394,10 @@ impl BitcoinRpcClient {
         password: Option<String>,
     ) -> Result<Self> {
         // Try cookie auth first if bitcoin_dir is provided
-        if let Some(dir) = bitcoin_dir {
-            if let Ok(client) = Self::new_with_cookie(url.clone(), dir) {
-                return Ok(client);
-            }
+        if let Some(dir) = bitcoin_dir
+            && let Ok(client) = Self::new_with_cookie(url.clone(), dir)
+        {
+            return Ok(client);
         }
 
         // Fall back to username/password
@@ -453,10 +453,10 @@ impl BitcoinRpcClient {
 
         let json: serde_json::Value = response.json().await?;
 
-        if let Some(error) = json.get("error") {
-            if !error.is_null() {
-                bail!("RPC error: {error}");
-            }
+        if let Some(error) = json.get("error")
+            && !error.is_null()
+        {
+            bail!("RPC error: {error}");
         }
 
         json.get("result")
@@ -783,12 +783,11 @@ impl BitcoinRpcClient {
         if let Ok(result) = self
             .rpc_call("deriveaddresses", serde_json::Value::Array(derive_params))
             .await
+            && let Some(addr_array) = result.as_array()
         {
-            if let Some(addr_array) = result.as_array() {
-                for addr in addr_array {
-                    if let Some(addr_str) = addr.as_str() {
-                        addresses.push(addr_str.to_string());
-                    }
+            for addr in addr_array {
+                if let Some(addr_str) = addr.as_str() {
+                    addresses.push(addr_str.to_string());
                 }
             }
         }
@@ -1073,10 +1072,10 @@ impl BitcoinRpcClient {
             .rpc_call("deriveaddresses", serde_json::Value::Array(params))
             .await?;
 
-        if let Some(addresses) = result.as_array() {
-            if let Some(address) = addresses.first().and_then(|v| v.as_str()) {
-                return Ok(address.to_string());
-            }
+        if let Some(addresses) = result.as_array()
+            && let Some(address) = addresses.first().and_then(|v| v.as_str())
+        {
+            return Ok(address.to_string());
         }
 
         bail!("Failed to derive address from descriptor: {descriptor}");

--- a/cyberkrill-core/src/coldcard.rs
+++ b/cyberkrill-core/src/coldcard.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use bitcoin::bip32::Xpub;
 use coldcard::{
-    protocol::{AddressFormat, DerivationPath},
     Api, Coldcard as ColdcardDevice, SignMode,
+    protocol::{AddressFormat, DerivationPath},
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -254,7 +254,9 @@ pub async fn export_psbt_to_coldcard(psbt_data: &[u8], filename: &str) -> Result
         .sign_psbt(psbt_data, SignMode::Finalize)
         .context("Failed to prepare PSBT for Coldcard")?;
 
-    Ok(format!("PSBT has been sent to Coldcard. Please save it to SD card as '{filename}' using the device menu."))
+    Ok(format!(
+        "PSBT has been sent to Coldcard. Please save it to SD card as '{filename}' using the device menu."
+    ))
 }
 
 #[cfg(test)]

--- a/cyberkrill-core/src/dca_report.rs
+++ b/cyberkrill-core/src/dca_report.rs
@@ -745,7 +745,7 @@ mod tests {
         // "not-a-date" splits into 3 parts: ["not", "a", "date"]
         let parts = "not-a-date".split('-').collect::<Vec<_>>();
         assert_eq!(parts.len(), 3); // Actually has 3 parts!
-                                    // But they're not valid numbers
+        // But they're not valid numbers
         assert!(parts[0].parse::<u32>().is_err());
 
         // "2024/06/15" has only 1 part when split by '-'

--- a/cyberkrill-core/src/decoder.rs
+++ b/cyberkrill-core/src/decoder.rs
@@ -265,15 +265,14 @@ pub async fn generate_invoice_from_address(
     }
 
     // Validate comment length if provided
-    if let Some(comment) = comment {
-        if let Some(max_comment_len) = lnurl_pay_request.comment_allowed {
-            if comment.len() > max_comment_len as usize {
-                anyhow::bail!(
-                    "Comment length {comment_len} exceeds maximum allowed length: {max_comment_len}",
-                    comment_len = comment.len()
-                );
-            }
-        }
+    if let Some(comment) = comment
+        && let Some(max_comment_len) = lnurl_pay_request.comment_allowed
+        && comment.len() > max_comment_len as usize
+    {
+        anyhow::bail!(
+            "Comment length {comment_len} exceeds maximum allowed length: {max_comment_len}",
+            comment_len = comment.len()
+        );
     }
 
     // Build callback URL with parameters

--- a/cyberkrill-core/src/frozenkrill.rs
+++ b/cyberkrill-core/src/frozenkrill.rs
@@ -356,8 +356,10 @@ mod tests {
 
         assert_eq!(wallet.network(), Network::Bitcoin);
         assert_eq!(wallet.wallet_type(), "2-of-3");
-        assert!(wallet
-            .contains_address("bc1q9h4r8pk4p6ufsaaqpk5w09h7fr983nf9pcef6vfqcujawge2m3ssaqs7dp"));
+        assert!(
+            wallet
+                .contains_address("bc1q9h4r8pk4p6ufsaaqpk5w09h7fr983nf9pcef6vfqcujawge2m3ssaqs7dp")
+        );
         assert_eq!(wallet.master_fingerprint(), None); // No fingerprint for multisig
 
         Ok(())
@@ -379,12 +381,16 @@ mod tests {
 
         let wallet = FrozenkrillWallet::from_file(temp_file.path())?;
 
-        assert!(wallet
-            .receiving_descriptor()
-            .starts_with("wpkh([84577e03/84'/0'/0']"));
-        assert!(wallet
-            .change_descriptor()
-            .starts_with("wpkh([84577e03/84'/0'/0']"));
+        assert!(
+            wallet
+                .receiving_descriptor()
+                .starts_with("wpkh([84577e03/84'/0'/0']")
+        );
+        assert!(
+            wallet
+                .change_descriptor()
+                .starts_with("wpkh([84577e03/84'/0'/0']")
+        );
         assert!(wallet.receiving_descriptor().ends_with("/0/*)#x703tmpk"));
         assert!(wallet.change_descriptor().ends_with("/1/*)#h22skw3w"));
 

--- a/cyberkrill-core/src/jade.rs
+++ b/cyberkrill-core/src/jade.rs
@@ -1,6 +1,6 @@
 //! Jade hardware wallet integration
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use jade_bitcoin::{JadeClient, Network as JadeNetwork};
 use serde::{Deserialize, Serialize};
 

--- a/cyberkrill-core/src/lib.rs
+++ b/cyberkrill-core/src/lib.rs
@@ -22,24 +22,24 @@ pub mod jade;
 
 // Re-export main functionality for easier access
 pub use decoder::{
-    decode_invoice, decode_lnurl, generate_invoice_from_address, GeneratedInvoiceOutput,
-    InvoiceOutput, LnurlOutput,
+    GeneratedInvoiceOutput, InvoiceOutput, LnurlOutput, decode_invoice, decode_lnurl,
+    generate_invoice_from_address,
 };
 
 #[cfg(feature = "smartcards")]
-pub use satscard::{generate_satscard_address, SatscardAddressOutput, SatscardInfo};
+pub use satscard::{SatscardAddressOutput, SatscardInfo, generate_satscard_address};
 
 #[cfg(feature = "smartcards")]
 pub use tapsigner::{
-    generate_tapsigner_address, initialize_tapsigner, TapsignerAddressOutput, TapsignerInitOutput,
+    TapsignerAddressOutput, TapsignerInitOutput, generate_tapsigner_address, initialize_tapsigner,
 };
 
 pub use bitcoin_rpc::{AmountInput, BitcoinRpcClient};
 
 pub use bdk_wallet::{
-    create_funded_psbt_bdk, create_psbt_bdk, get_utxo_summary, list_utxos_bdk, move_utxos_bdk,
-    scan_and_list_utxos_bitcoind, scan_and_list_utxos_electrum, scan_and_list_utxos_esplora,
-    BdkPsbtResponse, BdkUtxo, BdkUtxoSummary,
+    BdkPsbtResponse, BdkUtxo, BdkUtxoSummary, create_funded_psbt_bdk, create_psbt_bdk,
+    get_utxo_summary, list_utxos_bdk, move_utxos_bdk, scan_and_list_utxos_bitcoind,
+    scan_and_list_utxos_electrum, scan_and_list_utxos_esplora,
 };
 
 // Re-export bitcoin types needed by CLI
@@ -55,23 +55,23 @@ pub use frozenkrill::FrozenkrillWallet;
 // Re-export coldcard functionality
 #[cfg(feature = "coldcard")]
 pub use coldcard::{
-    export_psbt_to_coldcard, generate_coldcard_address, sign_psbt_with_coldcard,
-    ColdcardAddressOutput, ColdcardSignOutput, ColdcardWallet,
+    ColdcardAddressOutput, ColdcardSignOutput, ColdcardWallet, export_psbt_to_coldcard,
+    generate_coldcard_address, sign_psbt_with_coldcard,
 };
 
 // Re-export trezor functionality
 #[cfg(feature = "trezor")]
 pub use trezor::{
-    generate_trezor_address, sign_psbt_with_trezor, TrezorAddressOutput, TrezorSignOutput,
-    TrezorWallet,
+    TrezorAddressOutput, TrezorSignOutput, TrezorWallet, generate_trezor_address,
+    sign_psbt_with_trezor,
 };
 
 // Re-export jade functionality
 #[cfg(feature = "jade")]
 pub use jade::{
-    generate_jade_address, generate_jade_xpub, sign_psbt_with_jade, JadeAddressResult,
-    JadeSignedPsbtResult, JadeXpubResult,
+    JadeAddressResult, JadeSignedPsbtResult, JadeXpubResult, generate_jade_address,
+    generate_jade_xpub, sign_psbt_with_jade,
 };
 
 // Re-export DCA report functionality
-pub use dca_report::{generate_dca_report, Backend, DcaMetrics, DcaReport, DcaUtxo};
+pub use dca_report::{Backend, DcaMetrics, DcaReport, DcaUtxo, generate_dca_report};

--- a/cyberkrill-core/src/satscard.rs
+++ b/cyberkrill-core/src/satscard.rs
@@ -2,9 +2,9 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 // Satscard imports - correct API usage
-use bitcoin::{key::CompressedPublicKey, network::Network, Address};
+use bitcoin::{Address, key::CompressedPublicKey, network::Network};
 use cktap_direct::commands::Read;
-use cktap_direct::{discovery::find_first, CkTapCard}; // Required trait import for read() method
+use cktap_direct::{CkTapCard, discovery::find_first}; // Required trait import for read() method
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SatscardAddressOutput {

--- a/cyberkrill-core/src/slip132.rs
+++ b/cyberkrill-core/src/slip132.rs
@@ -1,7 +1,7 @@
 // SLIP-0132 extended public key format support
 // Adapted from frozenkrill-core for Trezor compatibility
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use bitcoin::base58;
 use bitcoin::bip32::Xpub;
 

--- a/cyberkrill-core/src/tapsigner.rs
+++ b/cyberkrill-core/src/tapsigner.rs
@@ -8,14 +8,14 @@ use crate::satscard::{SatscardAddressOutput, SatscardInfo};
 
 // Tapsigner imports
 use bitcoin::{
+    Address,
     bip32::{DerivationPath, Xpub},
-    hashes::{hash160, Hash},
+    hashes::{Hash, hash160},
     key::CompressedPublicKey,
     network::Network,
     secp256k1::{PublicKey, Secp256k1},
-    Address,
 };
-use cktap_direct::{discovery::find_first, CkTapCard, TapSigner};
+use cktap_direct::{CkTapCard, TapSigner, discovery::find_first};
 use sha2::{Digest, Sha256};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -95,9 +95,9 @@ pub async fn initialize_tapsigner(chain_code: Option<String>) -> Result<Tapsigne
     // Generate or use provided chain code
     let chain_code_bytes = match chain_code {
         Some(hex_str) => {
-            let bytes = hex::decode(hex_str.trim()).with_context(|| {
-                "Invalid hex format for chain code. Must be 64 hex characters (32 bytes)."
-            })?;
+            let bytes = hex::decode(hex_str.trim()).with_context(
+                || "Invalid hex format for chain code. Must be 64 hex characters (32 bytes).",
+            )?;
             if bytes.len() != 32 {
                 anyhow::bail!(
                     "Chain code must be exactly 32 bytes (64 hex characters). Got {len} bytes.",
@@ -138,7 +138,9 @@ pub async fn initialize_tapsigner(chain_code: Option<String>) -> Result<Tapsigne
     // Verify initialization was successful by checking the status
     let new_status = tapsigner.status().await?;
     if new_status.path.is_none() {
-        anyhow::bail!("Initialization appeared to succeed but card still shows uninitialized state. Please try again.");
+        anyhow::bail!(
+            "Initialization appeared to succeed but card still shows uninitialized state. Please try again."
+        );
     }
 
     info!("✅ Tapsigner initialization successful!");
@@ -250,7 +252,9 @@ async fn connect_tapsigner() -> Result<TapsignerDevice<cktap_direct::usb_transpo
         CkTapCard::TapSigner(tapsigner) => Ok(TapsignerDevice::TapSigner(Box::new(tapsigner))),
         CkTapCard::SatsChip(tapsigner) => Ok(TapsignerDevice::TapSigner(Box::new(tapsigner))), // SatsChip is also a TapSigner
         _ => {
-            anyhow::bail!("Found CkTap card but it's not a TapSigner. Make sure you're using a TapSigner card.")
+            anyhow::bail!(
+                "Found CkTap card but it's not a TapSigner. Make sure you're using a TapSigner card."
+            )
         }
     }
 }
@@ -266,7 +270,9 @@ async fn connect_tapsigner_direct() -> Result<TapSigner<cktap_direct::usb_transp
         CkTapCard::TapSigner(tapsigner) => Ok(tapsigner),
         CkTapCard::SatsChip(tapsigner) => Ok(tapsigner), // SatsChip is also a TapSigner
         _ => {
-            anyhow::bail!("Found CkTap card but it's not a TapSigner. Make sure you're using a TapSigner card.")
+            anyhow::bail!(
+                "Found CkTap card but it's not a TapSigner. Make sure you're using a TapSigner card."
+            )
         }
     }
 }

--- a/cyberkrill-core/src/trezor.rs
+++ b/cyberkrill-core/src/trezor.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, bail, Context, Result};
-use bitcoin::bip32::{ChildNumber, DerivationPath, Xpub};
+use anyhow::{Context, Result, anyhow, bail};
 use bitcoin::Network;
+use bitcoin::bip32::{ChildNumber, DerivationPath, Xpub};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::warn;

--- a/cyberkrill/Cargo.toml
+++ b/cyberkrill/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cyberkrill"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 description = "CLI utility for Bitcoin and Lightning Network operations"
 license = "MIT"
 repository = "https://github.com/douglaz/cyberkrill"

--- a/cyberkrill/src/main.rs
+++ b/cyberkrill/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use clap::{Parser, Subcommand};
 use cyberkrill_core::AmountInput;
 use std::io::{BufWriter, Read, Write};
@@ -1442,7 +1442,7 @@ async fn jade_sign_psbt(args: JadeSignPsbtArgs) -> anyhow::Result<()> {
 }
 
 fn decode_psbt(args: DecodePsbtArgs) -> anyhow::Result<()> {
-    use cyberkrill_core::bitcoin::{psbt::Psbt, Network};
+    use cyberkrill_core::bitcoin::{Network, psbt::Psbt};
     use std::str::FromStr;
 
     // Parse network
@@ -1668,7 +1668,7 @@ async fn coldcard_export_psbt(args: ColdcardExportPsbtArgs) -> anyhow::Result<()
 
 #[cfg(feature = "trezor")]
 async fn trezor_address(args: TrezorAddressArgs) -> anyhow::Result<()> {
-    use cyberkrill_core::{generate_trezor_address, Network};
+    use cyberkrill_core::{Network, generate_trezor_address};
 
     let network = args
         .network
@@ -1691,7 +1691,7 @@ async fn trezor_address(args: TrezorAddressArgs) -> anyhow::Result<()> {
 
 #[cfg(feature = "trezor")]
 async fn trezor_sign_psbt(args: TrezorSignPsbtArgs) -> anyhow::Result<()> {
-    use cyberkrill_core::{sign_psbt_with_trezor, Network};
+    use cyberkrill_core::{Network, sign_psbt_with_trezor};
 
     let network = args
         .network
@@ -1733,7 +1733,7 @@ async fn trezor_sign_psbt(args: TrezorSignPsbtArgs) -> anyhow::Result<()> {
 }
 
 async fn dca_report(args: DcaReportArgs) -> anyhow::Result<()> {
-    use cyberkrill_core::{generate_dca_report, Backend};
+    use cyberkrill_core::{Backend, generate_dca_report};
 
     // Determine backend based on arguments
     let backend = if let Some(bitcoin_dir) = args.bitcoin_dir {

--- a/cyberkrill/src/mcp_server.rs
+++ b/cyberkrill/src/mcp_server.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use rmcp::{
+    ErrorData as McpError, RoleServer,
     handler::server::ServerHandler,
     model::{
         CallToolRequestParam, CallToolResult, Content, ListToolsResult, PaginatedRequestParam,
@@ -9,7 +10,6 @@ use rmcp::{
     service::{RequestContext, ServiceExt},
     tool,
     transport::stdio,
-    ErrorData as McpError, RoleServer,
 };
 use serde::Deserialize;
 use std::future::Future;
@@ -448,7 +448,7 @@ impl CyberkrillMcpServer {
             _ => {
                 return CallToolResult::error(vec![Content::text(format!(
                     "Invalid network: {network_str}"
-                ))])
+                ))]);
             }
         };
 
@@ -474,7 +474,7 @@ impl CyberkrillMcpServer {
                         Err(e) => {
                             return CallToolResult::error(vec![Content::text(format!(
                                 "Error: {e}"
-                            ))])
+                            ))]);
                         }
                     }
                 }
@@ -486,7 +486,7 @@ impl CyberkrillMcpServer {
                         Err(e) => {
                             return CallToolResult::error(vec![Content::text(format!(
                                 "Error: {e}"
-                            ))])
+                            ))]);
                         }
                     }
                 }
@@ -498,7 +498,7 @@ impl CyberkrillMcpServer {
                         Err(e) => {
                             return CallToolResult::error(vec![Content::text(format!(
                                 "Error: {e}"
-                            ))])
+                            ))]);
                         }
                     }
                 }
@@ -515,7 +515,7 @@ impl CyberkrillMcpServer {
                 Err(e) => {
                     return CallToolResult::error(vec![Content::text(format!(
                         "Error creating client: {e}"
-                    ))])
+                    ))]);
                 }
             };
 
@@ -564,7 +564,7 @@ impl CyberkrillMcpServer {
                 Err(e) => {
                     return CallToolResult::error(vec![Content::text(format!(
                         "Error decoding base64: {e}"
-                    ))])
+                    ))]);
                 }
             }
         } else {
@@ -573,7 +573,7 @@ impl CyberkrillMcpServer {
                 Err(e) => {
                     return CallToolResult::error(vec![Content::text(format!(
                         "Error decoding hex: {e}"
-                    ))])
+                    ))]);
                 }
             }
         };
@@ -619,7 +619,7 @@ impl CyberkrillMcpServer {
             _ => {
                 return CallToolResult::error(vec![Content::text(format!(
                     "Invalid network: {network_str}"
-                ))])
+                ))]);
             }
         };
 
@@ -629,7 +629,7 @@ impl CyberkrillMcpServer {
                 Err(e) => {
                     return CallToolResult::error(vec![Content::text(format!(
                         "Invalid fee rate: {e}"
-                    ))])
+                    ))]);
                 }
             }
         } else {
@@ -671,7 +671,7 @@ impl CyberkrillMcpServer {
                         Err(e) => {
                             return CallToolResult::error(vec![Content::text(format!(
                                 "Invalid amount in output '{output}': {e}"
-                            ))])
+                            ))]);
                         }
                     }
                 } else {
@@ -709,7 +709,7 @@ impl CyberkrillMcpServer {
                 Err(e) => {
                     return CallToolResult::error(vec![Content::text(format!(
                         "Error creating client: {e}"
-                    ))])
+                    ))]);
                 }
             };
 
@@ -749,7 +749,7 @@ impl CyberkrillMcpServer {
             _ => {
                 return CallToolResult::error(vec![Content::text(format!(
                     "Invalid network: {network_str}"
-                ))])
+                ))]);
             }
         };
 
@@ -759,7 +759,7 @@ impl CyberkrillMcpServer {
                 Err(e) => {
                     return CallToolResult::error(vec![Content::text(format!(
                         "Invalid fee rate: {e}"
-                    ))])
+                    ))]);
                 }
             }
         } else {
@@ -801,7 +801,7 @@ impl CyberkrillMcpServer {
                         Err(e) => {
                             return CallToolResult::error(vec![Content::text(format!(
                                 "Invalid amount in output '{output}': {e}"
-                            ))])
+                            ))]);
                         }
                     }
                 } else {
@@ -850,7 +850,7 @@ impl CyberkrillMcpServer {
                             Err(e) => {
                                 return CallToolResult::error(vec![Content::text(format!(
                                     "Invalid fee rate: {e}"
-                                ))])
+                                ))]);
                             }
                         }
                     } else {
@@ -907,7 +907,7 @@ impl CyberkrillMcpServer {
             _ => {
                 return CallToolResult::error(vec![Content::text(format!(
                     "Invalid network: {network_str}"
-                ))])
+                ))]);
             }
         };
 
@@ -917,7 +917,7 @@ impl CyberkrillMcpServer {
                 Err(e) => {
                     return CallToolResult::error(vec![Content::text(format!(
                         "Invalid fee rate: {e}"
-                    ))])
+                    ))]);
                 }
             }
         } else {
@@ -930,7 +930,7 @@ impl CyberkrillMcpServer {
                 Err(e) => {
                     return CallToolResult::error(vec![Content::text(format!(
                         "Invalid max_amount: {e}"
-                    ))])
+                    ))]);
                 }
             }
         } else {
@@ -986,7 +986,7 @@ impl CyberkrillMcpServer {
                 Err(e) => {
                     return CallToolResult::error(vec![Content::text(format!(
                         "Error creating client: {e}"
-                    ))])
+                    ))]);
                 }
             };
 

--- a/cyberkrill/src/mcp_server.rs
+++ b/cyberkrill/src/mcp_server.rs
@@ -636,7 +636,7 @@ impl CyberkrillMcpServer {
             None
         };
 
-        let result = if let Some(desc) = descriptor {
+        if let Some(desc) = descriptor {
             // BDK path - select backend with fallback
             let backend_config = match Self::select_backend(
                 backend.as_deref(),
@@ -719,9 +719,7 @@ impl CyberkrillMcpServer {
                 )]),
                 Err(e) => CallToolResult::error(vec![Content::text(format!("Error: {e}"))]),
             }
-        };
-
-        result
+        }
     }
 
     #[tool(description = "Create funded PSBT with automatic input selection")]
@@ -766,7 +764,7 @@ impl CyberkrillMcpServer {
             None
         };
 
-        let result = if let Some(desc) = descriptor {
+        if let Some(desc) = descriptor {
             // BDK path - select backend with fallback
             let backend_config = match Self::select_backend(
                 backend.as_deref(),
@@ -877,9 +875,7 @@ impl CyberkrillMcpServer {
                     "Error creating Bitcoin RPC client: {e}"
                 ))]),
             }
-        };
-
-        result
+        }
     }
 
     #[tool(description = "Consolidate/move UTXOs to a single destination")]
@@ -937,7 +933,7 @@ impl CyberkrillMcpServer {
             None
         };
 
-        let result = if let Some(desc) = descriptor {
+        if let Some(desc) = descriptor {
             // BDK path - select backend with fallback
             let backend_config = match Self::select_backend(
                 backend.as_deref(),
@@ -1005,9 +1001,7 @@ impl CyberkrillMcpServer {
                 )]),
                 Err(e) => CallToolResult::error(vec![Content::text(format!("Error: {e}"))]),
             }
-        };
-
-        result
+        }
     }
 
     #[tool(description = "Generate DCA (Dollar Cost Averaging) report for UTXOs")]

--- a/cyberkrill/tests/mcp_client_test.rs
+++ b/cyberkrill/tests/mcp_client_test.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use rmcp::{
+    ServiceExt,
     model::CallToolRequestParam,
     transport::{ConfigureCommandExt, TokioChildProcess},
-    ServiceExt,
 };
 use serde_json::json;
 

--- a/cyberkrill/tests/mcp_integration_test.rs
+++ b/cyberkrill/tests/mcp_integration_test.rs
@@ -1,6 +1,6 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;

--- a/cyberkrill/tests/mcp_integration_test.rs
+++ b/cyberkrill/tests/mcp_integration_test.rs
@@ -159,16 +159,16 @@ impl McpTestClient {
         // Extract the content from the response
         if let Some(result) = response.result {
             // The result should have a "content" field with an array of content items
-            if let Some(content_array) = result.get("content").and_then(|c| c.as_array()) {
-                if let Some(first_content) = content_array.first() {
-                    // Each content item has a "text" field with the actual response
-                    if let Some(text) = first_content.get("text").and_then(|t| t.as_str()) {
-                        // Try to parse the text as JSON, or return as string
-                        if let Ok(parsed) = serde_json::from_str::<Value>(text) {
-                            return Ok(parsed);
-                        } else {
-                            return Ok(Value::String(text.to_string()));
-                        }
+            if let Some(content_array) = result.get("content").and_then(|c| c.as_array())
+                && let Some(first_content) = content_array.first()
+            {
+                // Each content item has a "text" field with the actual response
+                if let Some(text) = first_content.get("text").and_then(|t| t.as_str()) {
+                    // Try to parse the text as JSON, or return as string
+                    if let Ok(parsed) = serde_json::from_str::<Value>(text) {
+                        return Ok(parsed);
+                    } else {
+                        return Ok(Value::String(text.to_string()));
                     }
                 }
             }

--- a/fedimint-lite/Cargo.toml
+++ b/fedimint-lite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fedimint-lite"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["cyberkrill Contributors"]
 description = "Lightweight Fedimint invite code encoder/decoder library"
 license = "MIT OR Apache-2.0"

--- a/fedimint-lite/src/lib.rs
+++ b/fedimint-lite/src/lib.rs
@@ -66,8 +66,8 @@ pub fn decode_fedimint_invite(input: &str) -> Result<FedimintInviteOutput> {
 
 fn decode_bech32m_invite(input: &str) -> Result<FedimintInviteOutput> {
     // Decode and validate bech32m checksum
-    use bech32::primitives::decode::CheckedHrpstring;
     use bech32::Bech32m;
+    use bech32::primitives::decode::CheckedHrpstring;
 
     let checked = CheckedHrpstring::new::<Bech32m>(input)
         .map_err(|e| anyhow::anyhow!("Invalid bech32m string: {e}"))?;

--- a/jade-bitcoin/Cargo.toml
+++ b/jade-bitcoin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jade-bitcoin"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["cyberkrill Contributors"]
 description = "Bitcoin-focused Rust client for Blockstream Jade hardware wallet"
 repository = "https://github.com/douglaz/cyberkrill"

--- a/jade-bitcoin/src/protocol.rs
+++ b/jade-bitcoin/src/protocol.rs
@@ -1,11 +1,11 @@
 //! Jade protocol implementation
 
 use crate::error::{Error, Result};
-use crate::messages::{error_codes, methods, Request, ResponseBody};
+use crate::messages::{Request, ResponseBody, error_codes, methods};
 use crate::serial::SerialConnection;
 use crate::types::Network;
 use log::{debug, info};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Low-level protocol handler for Jade communication
 pub struct JadeProtocol {

--- a/jade-bitcoin/src/serial.rs
+++ b/jade-bitcoin/src/serial.rs
@@ -5,7 +5,7 @@ use crate::messages::{Request, Response};
 use crate::types::{JADE_USB_IDS, SERIAL_BAUD_RATE, SERIAL_TIMEOUT_MS};
 use log::debug;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::time::{sleep, timeout, Duration};
+use tokio::time::{Duration, sleep, timeout};
 use tokio_serial::{SerialPortBuilderExt, SerialStream};
 
 /// Async serial connection to Jade device


### PR DESCRIPTION
## Summary
- Updates all workspace crates from Rust edition 2021 to 2024
- Applies clippy suggestions for improved let-chain syntax

## Changes
- Updated `edition = "2021"` to `edition = "2024"` in all Cargo.toml files
- Applied clippy fixes for collapsible if statements using Rust 2024's let-chain syntax
- No functional changes, only syntax improvements

## Test Plan
- [x] All tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)