### PR TITLE
feat: add ln-encode-invoice command to reconstruct BOLT11 invoices from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A comprehensive Bitcoin and Lightning Network toolkit written in Rust. cyberkril
 
 ### 🌩️ Lightning Network
 - **BOLT11 Invoice Decoding**: Parse and analyze Lightning invoices
+- **BOLT11 Invoice Encoding**: Reconstruct Lightning invoices from JSON data
 - **LNURL Support**: Decode and process LNURL strings
 - **Lightning Address**: Generate invoices from Lightning addresses (user@domain.com)
 - **Fedimint Integration**: Encode/decode federation invite codes
@@ -162,6 +163,11 @@ cargo build --release --no-default-features
 ```bash
 # Decode a Lightning invoice
 cyberkrill ln-decode-invoice lnbc1000n1pn...
+
+# Encode a Lightning invoice from JSON data
+cyberkrill ln-encode-invoice invoice.json --private-key <hex_private_key>
+# Or from stdin
+echo '{"network":"bitcoin","amount_msats":1000000,...}' | cyberkrill ln-encode-invoice --private-key <hex_private_key>
 
 # Decode LNURL
 cyberkrill ln-decode-lnurl lnurl1dp68gurn8ghj7mr0v...

--- a/cyberkrill-core/src/lib.rs
+++ b/cyberkrill-core/src/lib.rs
@@ -23,7 +23,7 @@ pub mod jade;
 // Re-export main functionality for easier access
 pub use decoder::{
     GeneratedInvoiceOutput, InvoiceOutput, LnurlOutput, decode_invoice, decode_lnurl,
-    generate_invoice_from_address,
+    encode_invoice, generate_invoice_from_address,
 };
 
 #[cfg(feature = "smartcards")]


### PR DESCRIPTION
## Summary
This PR adds the inverse operation of `ln-decode-invoice` - a new `ln-encode-invoice` command that converts JSON invoice data back to a BOLT11 Lightning invoice string.

## Changes
- Added `encode_invoice()` function in `cyberkrill-core` that reconstructs BOLT11 invoices from the `InvoiceOutput` JSON structure
- Implemented comprehensive invoice building with support for all fields:
  - Required: payment hash, payment secret, description (or description hash), timestamp
  - Optional: amount, expiry time, routes, fallback addresses
- Added CLI command `ln-encode-invoice` that accepts JSON input and a private key for signing
- Support for all Lightning networks: Bitcoin, Testnet, Regtest, Signet, Simnet
- Updated documentation with usage examples

## Usage
```bash
# Encode from JSON file
cyberkrill ln-encode-invoice invoice.json --private-key <hex_private_key>

# Encode from stdin
echo '{"network":"bitcoin","amount_msats":1000000,...}' | cyberkrill ln-encode-invoice --private-key <hex_private_key>
```

## Technical Details
- Uses `lightning-invoice` crate's `InvoiceBuilder` for proper BOLT11 construction
- Handles network-specific address validation for fallback addresses
- Signs invoices with ECDSA recoverable signatures
- Includes comprehensive test coverage for roundtrip encoding/decoding

## Test Plan
- [x] Unit tests pass for invoice encoding
- [x] Roundtrip test verifies decode → encode → decode preserves data
- [x] CLI command produces valid BOLT11 format invoices
- [x] All code quality checks pass (formatting, clippy)