### PR TITLE
feat: add Lightning invoice encoding and remove Fedimint encoding_format

### DIFF
--- a/cyberkrill-core/src/bdk_wallet.rs
+++ b/cyberkrill-core/src/bdk_wallet.rs
@@ -462,8 +462,7 @@ impl FromStr for InputSpec {
             let parts: Vec<&str> = s.split(':').collect();
             ensure!(
                 parts.len() == 2,
-                "Invalid input format: '{}'. Expected 'txid:vout' or a descriptor",
-                s
+                "Invalid input format: '{s}'. Expected 'txid:vout' or a descriptor"
             );
             let txid = Txid::from_str(parts[0]).context("Invalid transaction ID")?;
             let vout: u32 = parts[1].parse().context("Invalid output index")?;

--- a/cyberkrill-core/src/bitcoin_rpc.rs
+++ b/cyberkrill-core/src/bitcoin_rpc.rs
@@ -827,8 +827,7 @@ impl BitcoinRpcClient {
                 let parts: Vec<&str> = input.split(':').collect();
                 ensure!(
                     parts.len() == 2,
-                    "Invalid input format: '{}'. Expected 'txid:vout' or a descriptor",
-                    input
+                    "Invalid input format: '{input}'. Expected 'txid:vout' or a descriptor"
                 );
                 let txid = parts[0];
                 let vout: u32 = parts[1].parse().map_err(|_| {

--- a/cyberkrill-core/src/trezor.rs
+++ b/cyberkrill-core/src/trezor.rs
@@ -61,12 +61,12 @@ impl TrezorWallet {
 
         Ok(DeviceInfo {
             device_type: "Trezor".to_string(),
-            version: {
-                let major = features.major_version();
-                let minor = features.minor_version();
-                let patch = features.patch_version();
-                format!("{major}.{minor}.{patch}")
-            },
+            version: format!(
+                "{}.{}.{}",
+                features.major_version(),
+                features.minor_version(),
+                features.patch_version()
+            ),
             initialized: features.initialized(),
             fingerprint: None, // Trezor doesn't expose master fingerprint directly
         })

--- a/cyberkrill-core/src/trezor.rs
+++ b/cyberkrill-core/src/trezor.rs
@@ -62,10 +62,10 @@ impl TrezorWallet {
         Ok(DeviceInfo {
             device_type: "Trezor".to_string(),
             version: format!(
-                "{}.{}.{}",
-                features.major_version(),
-                features.minor_version(),
-                features.patch_version()
+                "{major}.{minor}.{patch}",
+                major = features.major_version(),
+                minor = features.minor_version(),
+                patch = features.patch_version()
             ),
             initialized: features.initialized(),
             fingerprint: None, // Trezor doesn't expose master fingerprint directly

--- a/cyberkrill/src/mcp_server.rs
+++ b/cyberkrill/src/mcp_server.rs
@@ -415,7 +415,6 @@ impl CyberkrillMcpServer {
             } else {
                 api_secret
             },
-            encoding_format: "bech32m".to_string(),
         };
 
         match fedimint_lite::encode_fedimint_invite(&invite) {

--- a/fedimint-lite/README.md
+++ b/fedimint-lite/README.md
@@ -55,7 +55,6 @@ fn main() -> anyhow::Result<()> {
             }
         ],
         api_secret: None,
-        encoding_format: "bech32m".to_string(),
     };
     
     let encoded = encode_invite(&invite)?;


### PR DESCRIPTION
## Summary
- Add `ln-encode-invoice` command as the inverse of `ln-decode-invoice` to convert JSON back to BOLT11 Lightning invoice strings
- Remove `encoding_format` field from Fedimint invite structures since bech32m is the only supported format

## Changes

### Lightning Invoice Encoding
- Implement `encode_invoice` function to convert decoded invoice JSON back to BOLT11 format
- Add strong typing with custom wrapper types (PaymentHash, PaymentSecret, PublicKey, Sha256Hash)
- Support all Lightning networks (mainnet, testnet, signet, regtest)
- Include comprehensive roundtrip tests validating encode/decode cycle
- Accept SecretKey directly instead of hex string for better API

### Fedimint Simplification
- Remove `encoding_format` field from `FedimintInviteOutput` struct
- Simplify encoding/decoding to always use bech32m format implicitly
- Update MCP server and documentation accordingly

### Code Quality
- Replace if-bail patterns with `ensure!` macro for cleaner validation
- Fix all positional placeholder violations to comply with CONVENTIONS.md
- Use named placeholders throughout for better error messages

## Test Plan
- [x] All 135 existing tests pass
- [x] Roundtrip encoding/decoding works correctly for Lightning invoices
- [x] Fedimint invite encoding/decoding continues to work without encoding_format field
- [x] Manual testing confirms expected behavior

## Example Usage

### Lightning Invoice Encoding
```bash
# Decode an invoice to JSON
cyberkrill ln-decode-invoice "lnbc1..." > invoice.json

# Encode it back to BOLT11 format
cyberkrill ln-encode-invoice invoice.json --private-key <hex_key>
```

### Fedimint Invite (simplified)
```bash
# No longer need to specify encoding_format in JSON
echo '{"federation_id":"...", "guardians":[...]}' | cyberkrill fm-encode-invite -
```