### PR TITLE
feat: add BIP39 mnemonic generator command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,17 @@ dependencies = [
 [[package]]
 name = "bip39"
 version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d193de1f7487df1914d3a568b772458861d33f9c54249612cc2893d6915054"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bip39"
+version = "2.2.0"
 source = "git+https://github.com/rust-bitcoin/rust-bip39#5bb47117ba8d6c8d7f2fc601cfae78ef2cda643e"
 dependencies = [
  "bitcoin_hashes 0.13.0",
@@ -838,11 +849,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "bip39 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin",
  "clap",
  "cyberkrill-core",
  "fedimint-lite",
  "hex",
+ "rand 0.8.5",
  "rmcp",
  "rustls 0.23.31",
  "schemars",
@@ -1172,7 +1185,7 @@ source = "git+https://github.com/planktonlabs/frozenkrill?rev=c6883ec2daf9886f96
 dependencies = [
  "alkali",
  "anyhow",
- "bip39",
+ "bip39 2.2.0 (git+https://github.com/rust-bitcoin/rust-bip39)",
  "bitcoin",
  "blake3",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,17 +392,6 @@ dependencies = [
 [[package]]
 name = "bip39"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d193de1f7487df1914d3a568b772458861d33f9c54249612cc2893d6915054"
-dependencies = [
- "bitcoin_hashes 0.13.0",
- "serde",
- "unicode-normalization",
-]
-
-[[package]]
-name = "bip39"
-version = "2.2.0"
 source = "git+https://github.com/rust-bitcoin/rust-bip39#5bb47117ba8d6c8d7f2fc601cfae78ef2cda643e"
 dependencies = [
  "bitcoin_hashes 0.13.0",
@@ -849,7 +838,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "bip39 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bip39",
  "bitcoin",
  "clap",
  "cyberkrill-core",
@@ -1185,7 +1174,7 @@ source = "git+https://github.com/planktonlabs/frozenkrill?rev=c6883ec2daf9886f96
 dependencies = [
  "alkali",
  "anyhow",
- "bip39 2.2.0 (git+https://github.com/rust-bitcoin/rust-bip39)",
+ "bip39",
  "bitcoin",
  "blake3",
  "env_logger",

--- a/cyberkrill/Cargo.toml
+++ b/cyberkrill/Cargo.toml
@@ -31,6 +31,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 async-trait = "0.1"
 bitcoin = "0.32"
+bip39 = "2.1"
+rand = "0.8"
 
 [dev-dependencies]
 rmcp = { version = "0.6", features = ["server", "client", "transport-child-process"] }

--- a/cyberkrill/Cargo.toml
+++ b/cyberkrill/Cargo.toml
@@ -31,7 +31,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 async-trait = "0.1"
 bitcoin = "0.32"
-bip39 = "2.1"
+bip39 = { git = "https://github.com/rust-bitcoin/rust-bip39" }
 rand = "0.8"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Added new `generate-mnemonic` command to cyberkrill CLI
- Supports generating cryptographically secure BIP39 mnemonic phrases
- Configurable word count: 12, 15, 18, 21, or 24 words (defaults to 24)

## Details
This PR adds a utility command for generating BIP39 mnemonic phrases, which are commonly needed for:
- Creating wallets for Bitcoin/Lightning applications
- Generating secure seed phrases for nostr clients (like nostrweet)
- Testing wallet functionality

The implementation uses the `bip39` crate for mnemonic generation and `rand` for cryptographically secure random number generation.

## Usage
```bash
# Generate a 24-word mnemonic (default)
cyberkrill generate-mnemonic

# Generate a 12-word mnemonic
cyberkrill generate-mnemonic --words 12

# Save to file
cyberkrill generate-mnemonic -o mnemonic.json
```

## Test plan
- [x] Tested generation of mnemonics with different word counts
- [x] Verified output format is valid JSON
- [x] Confirmed generated mnemonics are valid BIP39 phrases
- [x] Code passes formatting and clippy checks