### PR TITLE
feat: accept fiat-denominated amounts via aggregated price feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /target
 *.local.*
 result
+
+# Local implementation scratch files
+/PLAN_FIAT_AMOUNTS.md
+/MEMPOOL_USAGE.md
+/test_mempool.sh

--- a/cyberkrill-core/src/lib.rs
+++ b/cyberkrill-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod dca_report;
 pub mod decoder;
 #[cfg(feature = "frozenkrill")]
 pub mod frozenkrill;
+pub mod price_feed;
 #[cfg(feature = "smartcards")]
 pub mod satscard;
 #[cfg(feature = "trezor")]
@@ -35,6 +36,8 @@ pub use tapsigner::{
 };
 
 pub use bitcoin_rpc::{AmountInput, BitcoinRpcClient};
+
+pub use price_feed::{BtcPrice, PriceQuote, fetch_btc_price};
 
 pub use bdk_wallet::{
     BdkPsbtResponse, BdkUtxo, BdkUtxoSummary, create_funded_psbt_bdk, create_psbt_bdk,

--- a/cyberkrill-core/src/price_feed.rs
+++ b/cyberkrill-core/src/price_feed.rs
@@ -1,0 +1,926 @@
+use anyhow::{Context, bail};
+use reqwest::Client;
+use serde::Serialize;
+use serde_json::Value;
+use std::time::Duration;
+use tokio::task::JoinSet;
+
+type FeedResponse = (&'static str, anyhow::Result<Option<PriceQuote>>);
+
+const MILLISATS_PER_BTC: f64 = 100_000_000_000.0;
+const PRICE_SPREAD_WARN_THRESHOLD: f64 = 0.02;
+// Current keyless public Fedi price endpoint; keep this in one place if it changes.
+const FEDI_PRICE_FEED_URL: &str = "https://price-feed.dev.fedibtc.com/latest";
+
+#[derive(Debug)]
+struct FeedCollection {
+    sources: Vec<PriceQuote>,
+    issues: Vec<String>,
+}
+
+/// Aggregated BTC price across multiple feeds.
+#[derive(Debug, Clone, Serialize)]
+pub struct BtcPrice {
+    /// ISO currency code, uppercase (e.g. "USD", "BRL").
+    pub currency: String,
+    /// Median price: how many units of `currency` equal 1 BTC.
+    pub price_per_btc: f64,
+    /// Per-feed quotes that contributed to the median.
+    pub sources: Vec<PriceQuote>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PriceQuote {
+    pub source: &'static str,
+    pub price_per_btc: f64,
+}
+
+impl BtcPrice {
+    /// Convert a fiat amount using this BTC price.
+    pub fn amount_to_btc(&self, amount: f64) -> anyhow::Result<crate::AmountInput> {
+        fiat_amount_to_btc_amount(amount, self.price_per_btc)
+    }
+}
+
+fn normalize_fiat_currency(currency: &str) -> anyhow::Result<String> {
+    let normalized = currency.trim().to_ascii_uppercase();
+    if normalized.len() != 3 || !normalized.chars().all(|c| c.is_ascii_alphabetic()) {
+        bail!("Invalid fiat currency code: '{currency}'");
+    }
+    Ok(normalized)
+}
+
+/// Fetch BTC price for `currency` from all configured feeds in parallel and return the median.
+///
+/// This contacts third-party HTTPS price feeds and does not reuse Bitcoin Core proxy settings.
+///
+/// Errors if fewer than 3 feeds succeed (the 3-source quorum makes the median
+/// a true middle value, so a single bad/poisoned feed cannot swing the result).
+pub async fn fetch_btc_price(currency: &str) -> anyhow::Result<BtcPrice> {
+    let currency = normalize_fiat_currency(currency)?;
+    let client = Client::builder()
+        .timeout(Duration::from_secs(8))
+        .user_agent(concat!("cyberkrill/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .context("Invalid BTC price feed client configuration")?;
+
+    let mut feeds = JoinSet::new();
+
+    {
+        let client = client.clone();
+        let currency = currency.clone();
+        feeds.spawn(async move { ("coingecko", fetch_coingecko(&client, &currency).await) });
+    }
+    {
+        let client = client.clone();
+        let currency = currency.clone();
+        feeds.spawn(async move { ("coinbase", fetch_coinbase(&client, &currency).await) });
+    }
+    {
+        let client = client.clone();
+        let currency = currency.clone();
+        feeds.spawn(async move {
+            (
+                "blockchain.info",
+                fetch_blockchain_info(&client, &currency).await,
+            )
+        });
+    }
+    {
+        let client = client.clone();
+        let currency = currency.clone();
+        feeds.spawn(async move { ("kraken", fetch_kraken(&client, &currency).await) });
+    }
+    {
+        let client = client.clone();
+        let currency = currency.clone();
+        feeds.spawn(async move { ("fedi", fetch_fedi(&client, &currency).await) });
+    }
+
+    let FeedCollection { sources, issues } = collect_feed_quotes(feeds, &currency).await;
+    let result = aggregate_btc_price(currency.clone(), sources);
+    if issues.is_empty() {
+        result
+    } else {
+        let issue_summary = format!(
+            "BTC price feed issues for {currency}: {issues}",
+            issues = issues.join("; ")
+        );
+        match result {
+            Ok(price) => {
+                // Trust signal — must reach stderr regardless of RUST_LOG.
+                eprintln!("[price-feed] {issue_summary}");
+                Ok(price)
+            }
+            Err(error) => Err(error).context(issue_summary),
+        }
+    }
+}
+
+fn aggregate_btc_price(currency: String, mut sources: Vec<PriceQuote>) -> anyhow::Result<BtcPrice> {
+    // Require at least 3 sources so the median is a true middle value: with 2
+    // sources the "median" is the arithmetic mean and a single bad/poisoned
+    // feed can swing the result by ~50% of the spread.
+    if sources.len() < 3 {
+        let feed_word = if sources.len() == 1 { "feed" } else { "feeds" };
+        bail!(
+            "Only {source_count} BTC price {feed_word} responded for {currency}; need at least 3 to compute a manipulation-resistant median",
+            source_count = sources.len()
+        );
+    }
+
+    sources.sort_by(|left, right| {
+        left.price_per_btc
+            .total_cmp(&right.price_per_btc)
+            .then_with(|| left.source.cmp(right.source))
+    });
+    let price_per_btc = median(
+        sources
+            .iter()
+            .map(|quote| quote.price_per_btc)
+            .collect::<Vec<_>>(),
+    )
+    .context("At least one BTC price source is required")?;
+    warn_if_price_spread_is_high(&currency, price_per_btc, &sources);
+
+    Ok(BtcPrice {
+        currency,
+        price_per_btc,
+        sources,
+    })
+}
+
+fn warn_if_price_spread_is_high(currency: &str, median_price: f64, sources: &[PriceQuote]) {
+    let Some(min) = sources.first() else {
+        return;
+    };
+    let Some(max) = sources.last() else {
+        return;
+    };
+
+    let spread = max.price_per_btc / min.price_per_btc - 1.0;
+    if spread > PRICE_SPREAD_WARN_THRESHOLD {
+        // Trust signal — must reach stderr regardless of RUST_LOG.
+        eprintln!(
+            "[price-feed] BTC price feed spread for {currency} is {spread_percent:.2}% \
+             ({min_source}={min_price:.2}, {max_source}={max_price:.2}); \
+             using median BTC/{currency}={median_price:.2}",
+            spread_percent = spread * 100.0,
+            min_source = min.source,
+            min_price = min.price_per_btc,
+            max_source = max.source,
+            max_price = max.price_per_btc
+        );
+    }
+}
+
+async fn collect_feed_quotes(mut feeds: JoinSet<FeedResponse>, currency: &str) -> FeedCollection {
+    let mut sources = Vec::new();
+    let mut issues = Vec::new();
+    while let Some(result) = feeds.join_next().await {
+        match result {
+            Ok((_source, Ok(Some(quote)))) => sources.push(quote),
+            Ok((source, Ok(None))) => {
+                issues.push(format!("{source}: no {currency} quote"));
+                tracing::debug!("BTC price feed {source} did not return {currency} quote");
+            }
+            Ok((source, Err(error))) => {
+                issues.push(format!("{source}: {error:#}"));
+                tracing::debug!("BTC price feed {source} failed for {currency}: {error:#}");
+            }
+            Err(error) => {
+                issues.push(format!("feed task failed: {error}"));
+                tracing::debug!("BTC price feed task failed for {currency}: {error}");
+            }
+        }
+    }
+    FeedCollection { sources, issues }
+}
+
+fn fiat_amount_to_btc_amount(
+    amount: f64,
+    price_per_btc: f64,
+) -> anyhow::Result<crate::AmountInput> {
+    let millisats = fiat_amount_to_millisats(amount, price_per_btc)?;
+    Ok(crate::AmountInput::from_millisats(millisats))
+}
+
+fn fiat_amount_to_millisats(amount: f64, price_per_btc: f64) -> anyhow::Result<u64> {
+    if !amount.is_finite() || amount < 0.0 {
+        bail!("Invalid fiat amount: {amount}");
+    }
+    if !price_per_btc.is_finite() || price_per_btc <= 0.0 {
+        bail!("Invalid BTC price: {price_per_btc}");
+    }
+
+    let rounded_millisats = (amount / price_per_btc * MILLISATS_PER_BTC).round();
+    if !rounded_millisats.is_finite()
+        || rounded_millisats < 0.0
+        || rounded_millisats >= u64::MAX as f64
+    {
+        bail!("Converted fiat amount is outside the supported range");
+    }
+
+    let millisats = rounded_millisats as u64;
+    if amount > 0.0 && millisats == 0 {
+        bail!("Converted non-zero fiat amount is less than 1 msat");
+    }
+    Ok(millisats)
+}
+
+fn median(mut values: Vec<f64>) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+
+    values.sort_by(f64::total_cmp);
+    let middle = values.len() / 2;
+    if values.len().is_multiple_of(2) {
+        Some((values[middle - 1] + values[middle]) / 2.0)
+    } else {
+        Some(values[middle])
+    }
+}
+
+async fn fetch_coingecko(client: &Client, currency: &str) -> anyhow::Result<Option<PriceQuote>> {
+    let lower = currency.to_ascii_lowercase();
+    let url =
+        format!("https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies={lower}");
+    let body = client
+        .get(url)
+        .send()
+        .await
+        .context("CoinGecko request failed")?
+        .error_for_status()
+        .context("CoinGecko returned an unsuccessful status")?
+        .text()
+        .await
+        .context("Failed to read CoinGecko response")?;
+
+    Ok(
+        parse_coingecko_price(&body, currency)?.map(|price_per_btc| PriceQuote {
+            source: "coingecko",
+            price_per_btc,
+        }),
+    )
+}
+
+async fn fetch_coinbase(client: &Client, currency: &str) -> anyhow::Result<Option<PriceQuote>> {
+    let body = client
+        .get("https://api.coinbase.com/v2/exchange-rates?currency=BTC")
+        .send()
+        .await
+        .context("Coinbase request failed")?
+        .error_for_status()
+        .context("Coinbase returned an unsuccessful status")?
+        .text()
+        .await
+        .context("Failed to read Coinbase response")?;
+
+    Ok(
+        parse_coinbase_price(&body, currency)?.map(|price_per_btc| PriceQuote {
+            source: "coinbase",
+            price_per_btc,
+        }),
+    )
+}
+
+async fn fetch_blockchain_info(
+    client: &Client,
+    currency: &str,
+) -> anyhow::Result<Option<PriceQuote>> {
+    let body = client
+        .get("https://blockchain.info/ticker")
+        .send()
+        .await
+        .context("Blockchain.info request failed")?
+        .error_for_status()
+        .context("Blockchain.info returned an unsuccessful status")?
+        .text()
+        .await
+        .context("Failed to read Blockchain.info response")?;
+
+    Ok(
+        parse_blockchain_info_price(&body, currency)?.map(|price_per_btc| PriceQuote {
+            source: "blockchain.info",
+            price_per_btc,
+        }),
+    )
+}
+
+async fn fetch_kraken(client: &Client, currency: &str) -> anyhow::Result<Option<PriceQuote>> {
+    let url = format!("https://api.kraken.com/0/public/Ticker?pair=XBT{currency}");
+    let body = client
+        .get(url)
+        .send()
+        .await
+        .context("Kraken request failed")?
+        .error_for_status()
+        .context("Kraken returned an unsuccessful status")?
+        .text()
+        .await
+        .context("Failed to read Kraken response")?;
+
+    Ok(
+        parse_kraken_price(&body, currency)?.map(|price_per_btc| PriceQuote {
+            source: "kraken",
+            price_per_btc,
+        }),
+    )
+}
+
+async fn fetch_fedi(client: &Client, currency: &str) -> anyhow::Result<Option<PriceQuote>> {
+    let body = client
+        .get(FEDI_PRICE_FEED_URL)
+        .send()
+        .await
+        .context("Fedi request failed")?
+        .error_for_status()
+        .context("Fedi returned an unsuccessful status")?
+        .text()
+        .await
+        .context("Failed to read Fedi response")?;
+
+    Ok(
+        parse_fedi_price(&body, currency)?.map(|price_per_btc| PriceQuote {
+            source: "fedi",
+            price_per_btc,
+        }),
+    )
+}
+
+fn parse_coingecko_price(json: &str, currency: &str) -> anyhow::Result<Option<f64>> {
+    let value: Value = serde_json::from_str(json).context("Invalid CoinGecko JSON")?;
+    let lower = currency.to_ascii_lowercase();
+    let Some(price) = value.get("bitcoin").and_then(|bitcoin| bitcoin.get(&lower)) else {
+        return Ok(None);
+    };
+
+    Ok(Some(parse_positive_price(price, "CoinGecko price")?))
+}
+
+fn parse_coinbase_price(json: &str, currency: &str) -> anyhow::Result<Option<f64>> {
+    let value: Value = serde_json::from_str(json).context("Invalid Coinbase JSON")?;
+    let Some(price) = value
+        .get("data")
+        .and_then(|data| data.get("rates"))
+        .and_then(|rates| rates.get(currency))
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(parse_positive_price(price, "Coinbase rate")?))
+}
+
+fn parse_blockchain_info_price(json: &str, currency: &str) -> anyhow::Result<Option<f64>> {
+    let value: Value = serde_json::from_str(json).context("Invalid Blockchain.info JSON")?;
+    let Some(price) = value
+        .get(currency)
+        .and_then(|currency_data| currency_data.get("last"))
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(parse_positive_price(
+        price,
+        "Blockchain.info last price",
+    )?))
+}
+
+fn parse_kraken_price(json: &str, currency: &str) -> anyhow::Result<Option<f64>> {
+    let value: Value = serde_json::from_str(json).context("Invalid Kraken JSON")?;
+    if value
+        .get("error")
+        .and_then(|errors| errors.as_array())
+        .is_some_and(|errors| !errors.is_empty())
+    {
+        return Ok(None);
+    }
+
+    let Some(result) = value.get("result").and_then(|result| result.as_object()) else {
+        return Ok(None);
+    };
+
+    let mut candidates = Vec::new();
+    for (pair, ticker) in result {
+        let Some(price) = ticker
+            .get("c")
+            .and_then(|close| close.as_array())
+            .and_then(|close| close.first())
+        else {
+            continue;
+        };
+
+        candidates.push((
+            pair.as_str(),
+            parse_positive_price(price, "Kraken close price")?,
+        ));
+    }
+
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    if candidates.len() == 1 {
+        return Ok(Some(candidates[0].1));
+    }
+
+    candidates.sort_by(|left, right| left.0.cmp(right.0));
+    if let Some((_, price)) = candidates.iter().find(|(pair, _)| pair.ends_with(currency)) {
+        return Ok(Some(*price));
+    }
+
+    Ok(None)
+}
+
+fn parse_fedi_price(json: &str, currency: &str) -> anyhow::Result<Option<f64>> {
+    let value: Value = serde_json::from_str(json).context("Invalid Fedi JSON")?;
+    let Some(prices) = value.get("prices").and_then(|prices| prices.as_object()) else {
+        return Ok(None);
+    };
+    let Some(btc_usd) = fedi_pair_rate(prices, "BTC/USD")? else {
+        return Ok(None);
+    };
+
+    if currency == "USD" {
+        return Ok(Some(btc_usd));
+    }
+
+    let pair = format!("{currency}/USD");
+    let Some(fiat_usd) = fedi_pair_rate(prices, &pair)? else {
+        return Ok(None);
+    };
+
+    // Fedi quotes are oriented as X/USD. This cross-rate uses the BTC/USD
+    // and fiat/USD rates from the same response as one median input source.
+    Ok(Some(validate_positive_price(
+        btc_usd / fiat_usd,
+        "Fedi cross-rate",
+    )?))
+}
+
+fn fedi_pair_rate(
+    prices: &serde_json::Map<String, Value>,
+    pair: &str,
+) -> anyhow::Result<Option<f64>> {
+    let Some(rate) = prices.get(pair).and_then(|pair_data| pair_data.get("rate")) else {
+        return Ok(None);
+    };
+
+    Ok(Some(parse_positive_price(rate, "Fedi rate")?))
+}
+
+fn parse_positive_price(value: &Value, label: &str) -> anyhow::Result<f64> {
+    let price = if let Some(price) = value.as_f64() {
+        price
+    } else if let Some(price) = value.as_str() {
+        price
+            .parse::<f64>()
+            .with_context(|| format!("{label} is not a number"))?
+    } else {
+        bail!("{label} is not a number");
+    };
+
+    validate_positive_price(price, label)
+}
+
+fn validate_positive_price(price: f64, label: &str) -> anyhow::Result<f64> {
+    if !price.is_finite() || price <= 0.0 {
+        bail!("{label} must be positive");
+    }
+
+    Ok(price)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: f64, expected: f64) {
+        let delta = (actual - expected).abs();
+        assert!(
+            delta < 0.000_001,
+            "actual {actual} was not close to expected {expected}"
+        );
+    }
+
+    #[test]
+    fn median_handles_ordering_and_even_counts() -> anyhow::Result<()> {
+        assert_close(median(vec![3.0, 1.0, 2.0]).context("odd median")?, 2.0);
+        assert_close(
+            median(vec![4.0, 1.0, 2.0, 3.0]).context("even median")?,
+            2.5,
+        );
+        assert_close(median(vec![8.0, 2.0]).context("two-value median")?, 5.0);
+        assert_close(
+            median(vec![10.0, 1.0, 9.0, 2.0, 8.0]).context("ordered median")?,
+            8.0,
+        );
+        assert!(median(Vec::new()).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn normalizes_three_letter_fiat_currency_codes() -> anyhow::Result<()> {
+        assert_eq!(normalize_fiat_currency(" usd ")?, "USD");
+        assert_eq!(normalize_fiat_currency("xau")?, "XAU");
+        assert!(normalize_fiat_currency("USDC").is_err());
+        assert!(normalize_fiat_currency("12A").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn fiat_conversion_rounds_to_nearest_millisat() -> anyhow::Result<()> {
+        assert_eq!(fiat_amount_to_millisats(100.0, 95_000.0)?, 105_263_158);
+        assert_eq!(
+            fiat_amount_to_millisats(50_000.0, 100_000.0)?,
+            50_000_000_000
+        );
+
+        let price = BtcPrice {
+            currency: "USD".to_string(),
+            price_per_btc: 95_000.0,
+            sources: vec![
+                PriceQuote {
+                    source: "feed-a",
+                    price_per_btc: 94_900.0,
+                },
+                PriceQuote {
+                    source: "feed-b",
+                    price_per_btc: 95_100.0,
+                },
+            ],
+        };
+        let amount = price.amount_to_btc(100.0)?;
+        assert_eq!(amount.as_sat(), 105_263);
+        assert_eq!(amount.as_millisats(), 105_263_158);
+
+        let error = fiat_amount_to_millisats(100.0, 0.0)
+            .err()
+            .context("zero price should fail")?
+            .to_string();
+        assert!(error.contains("Invalid BTC price"), "{error}");
+        Ok(())
+    }
+
+    #[test]
+    fn fiat_conversion_rejects_nonzero_amounts_that_round_to_zero_millisats() -> anyhow::Result<()>
+    {
+        let error = fiat_amount_to_millisats(0.00000001, 100_000.0)
+            .err()
+            .context("non-zero fiat amount below 1 msat should fail")?
+            .to_string();
+
+        assert!(
+            error.contains("Converted non-zero fiat amount is less than 1 msat"),
+            "{error}"
+        );
+        assert_eq!(fiat_amount_to_millisats(0.0, 100_000.0)?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn fiat_conversion_rejects_integer_overflow_after_float_rounding() -> anyhow::Result<()> {
+        let amount_that_would_overflow = u64::MAX as f64 / MILLISATS_PER_BTC + 1.0;
+        let error = fiat_amount_to_millisats(amount_that_would_overflow, 1.0)
+            .err()
+            .context("overflow-sized conversion should fail")?
+            .to_string();
+
+        assert!(
+            error.contains("Converted fiat amount is outside the supported range"),
+            "{error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn aggregate_requires_at_least_three_sources() -> anyhow::Result<()> {
+        let single_source_error = aggregate_btc_price(
+            "USD".to_string(),
+            vec![PriceQuote {
+                source: "coingecko",
+                price_per_btc: 100_000.0,
+            }],
+        )
+        .err()
+        .context("single source should fail")?
+        .to_string();
+
+        assert!(
+            single_source_error.contains("Only 1 BTC price feed responded for USD"),
+            "{single_source_error}"
+        );
+
+        let two_source_error = aggregate_btc_price(
+            "USD".to_string(),
+            vec![
+                PriceQuote {
+                    source: "coingecko",
+                    price_per_btc: 100_000.0,
+                },
+                PriceQuote {
+                    source: "coinbase",
+                    price_per_btc: 100_500.0,
+                },
+            ],
+        )
+        .err()
+        .context("two sources should still fail")?
+        .to_string();
+
+        assert!(
+            two_source_error.contains("Only 2 BTC price feeds responded for USD"),
+            "{two_source_error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn aggregate_sorts_sources_and_uses_median() -> anyhow::Result<()> {
+        let price = aggregate_btc_price(
+            "USD".to_string(),
+            vec![
+                PriceQuote {
+                    source: "z-feed",
+                    price_per_btc: 102_000.0,
+                },
+                PriceQuote {
+                    source: "a-feed",
+                    price_per_btc: 100_000.0,
+                },
+                PriceQuote {
+                    source: "m-feed",
+                    price_per_btc: 101_000.0,
+                },
+            ],
+        )?;
+
+        assert_eq!(price.currency, "USD");
+        assert_close(price.price_per_btc, 101_000.0);
+        assert_eq!(
+            price
+                .sources
+                .iter()
+                .map(|quote| quote.source)
+                .collect::<Vec<_>>(),
+            ["a-feed", "m-feed", "z-feed"]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn collect_feed_quotes_drops_missing_errors_and_join_errors() -> anyhow::Result<()> {
+        let mut feeds: JoinSet<FeedResponse> = JoinSet::new();
+        feeds.spawn(async {
+            (
+                "coingecko",
+                Ok(Some(PriceQuote {
+                    source: "coingecko",
+                    price_per_btc: 100_000.0,
+                })),
+            )
+        });
+        feeds.spawn(async { ("coinbase", Ok(None)) });
+        feeds.spawn(async { ("kraken", Err(anyhow::anyhow!("boom"))) });
+        feeds.spawn(async { panic!("feed task panicked") });
+
+        let collection = collect_feed_quotes(feeds, "USD").await;
+
+        assert_eq!(collection.sources.len(), 1);
+        assert_eq!(collection.sources[0].source, "coingecko");
+        assert_close(collection.sources[0].price_per_btc, 100_000.0);
+        assert_eq!(collection.issues.len(), 3);
+        assert!(
+            collection
+                .issues
+                .iter()
+                .any(|issue| issue.contains("coinbase: no USD quote"))
+        );
+        assert!(
+            collection
+                .issues
+                .iter()
+                .any(|issue| issue.contains("kraken: boom"))
+        );
+        assert!(
+            collection
+                .issues
+                .iter()
+                .any(|issue| issue.contains("feed task failed"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parses_coingecko_response() -> anyhow::Result<()> {
+        let json = r#"{"bitcoin":{"usd":104523.73,"brl":593424.10}}"#;
+
+        assert_close(
+            parse_coingecko_price(json, "USD")?.context("USD quote")?,
+            104523.73,
+        );
+        assert_close(
+            parse_coingecko_price(json, "BRL")?.context("BRL quote")?,
+            593424.10,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parses_coinbase_response() -> anyhow::Result<()> {
+        let json = r#"{
+            "data": {
+                "currency": "BTC",
+                "rates": {
+                    "USD": "104490.12",
+                    "BRL": "593000.45"
+                }
+            }
+        }"#;
+
+        assert_close(
+            parse_coinbase_price(json, "USD")?.context("USD quote")?,
+            104490.12,
+        );
+        assert_close(
+            parse_coinbase_price(json, "BRL")?.context("BRL quote")?,
+            593000.45,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parses_blockchain_info_response() -> anyhow::Result<()> {
+        let json = r#"{
+            "USD": {"15m": 104400.50, "last": 104400.50, "buy": 104400.50, "sell": 104400.50, "symbol": "$"},
+            "BRL": {"15m": 592900.25, "last": 592900.25, "buy": 592900.25, "sell": 592900.25, "symbol": "R$"}
+        }"#;
+
+        assert_close(
+            parse_blockchain_info_price(json, "USD")?.context("USD quote")?,
+            104400.50,
+        );
+        assert_close(
+            parse_blockchain_info_price(json, "BRL")?.context("BRL quote")?,
+            592900.25,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parses_kraken_response_without_assuming_pair_key() -> anyhow::Result<()> {
+        let usd_json = r#"{
+            "error": [],
+            "result": {
+                "XXBTZUSD": {
+                    "a": ["104600.00000", "1", "1.000"],
+                    "b": ["104599.90000", "1", "1.000"],
+                    "c": ["104555.12000", "0.00400000"]
+                }
+            }
+        }"#;
+        let aud_json = r#"{
+            "error": [],
+            "result": {
+                "XBTAUD": {
+                    "a": ["160100.00000", "1", "1.000"],
+                    "b": ["160099.90000", "1", "1.000"],
+                    "c": ["160055.99000", "0.01000000"]
+                }
+            }
+        }"#;
+
+        assert_close(
+            parse_kraken_price(usd_json, "USD")?.context("USD quote")?,
+            104555.12,
+        );
+        assert_close(
+            parse_kraken_price(aud_json, "AUD")?.context("AUD quote")?,
+            160055.99,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parses_kraken_response_with_extra_result_fields() -> anyhow::Result<()> {
+        let json = r#"{
+            "error": [],
+            "result": {
+                "metadata": {"note": "ignored"},
+                "XXBTZUSD": {"c": ["104555.12000", "0.00400000"]}
+            }
+        }"#;
+
+        assert_close(
+            parse_kraken_price(json, "USD")?.context("USD quote")?,
+            104555.12,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn kraken_parser_uses_matching_currency_when_multiple_tickers_are_present() -> anyhow::Result<()>
+    {
+        let json = r#"{
+            "error": [],
+            "result": {
+                "XXBTZEUR": {"c": ["95000.00000", "0.10000000"]},
+                "XXBTZUSD": {"c": ["104555.12000", "0.00400000"]}
+            }
+        }"#;
+
+        assert_close(
+            parse_kraken_price(json, "USD")?.context("USD quote")?,
+            104555.12,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn kraken_parser_uses_single_ticker_without_assuming_pair_key() -> anyhow::Result<()> {
+        let json = r#"{
+            "error": [],
+            "result": {
+                "UNEXPECTEDKEY": {"c": ["95000.00000", "0.10000000"]}
+            }
+        }"#;
+
+        assert_close(
+            parse_kraken_price(json, "USD")?.context("single quote")?,
+            95000.0,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parses_fedi_response_orientation() -> anyhow::Result<()> {
+        let json = r#"{
+            "prices": {
+                "BTC/USD": {"rate": 104000.00, "timestamp": 1760000000},
+                "BRL/USD": {"rate": 0.18, "timestamp": 1760000000},
+                "EUR/USD": {"rate": 1.08, "timestamp": 1760000000}
+            }
+        }"#;
+
+        assert_close(
+            parse_fedi_price(json, "USD")?.context("USD quote")?,
+            104000.00,
+        );
+        assert_close(
+            parse_fedi_price(json, "BRL")?.context("BRL quote")?,
+            104000.00 / 0.18,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_zero_fedi_cross_rate() -> anyhow::Result<()> {
+        let json = r#"{
+            "prices": {
+                "BTC/USD": {"rate": 104000.00, "timestamp": 1760000000},
+                "BRL/USD": {"rate": 0.0, "timestamp": 1760000000}
+            }
+        }"#;
+
+        let error = parse_fedi_price(json, "BRL")
+            .err()
+            .context("zero Fedi fiat rate should fail")?
+            .to_string();
+        assert!(error.contains("Fedi rate must be positive"), "{error}");
+        Ok(())
+    }
+
+    #[test]
+    fn fedi_parser_drops_source_without_btc_usd() -> anyhow::Result<()> {
+        let json = r#"{
+            "prices": {
+                "BRL/USD": {"rate": 0.18, "timestamp": 1760000000}
+            }
+        }"#;
+
+        assert!(parse_fedi_price(json, "BRL")?.is_none());
+        assert!(parse_fedi_price(json, "USD")?.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn live_fetch_btc_price() -> anyhow::Result<()> {
+        let price = fetch_btc_price("USD").await?;
+        println!(
+            "BTC/{currency} median = {price_per_btc} from {source_count} feeds: {sources}",
+            currency = price.currency,
+            price_per_btc = price.price_per_btc,
+            source_count = price.sources.len(),
+            sources = price
+                .sources
+                .iter()
+                .map(|quote| quote.source)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        assert!(price.sources.len() >= 2);
+        Ok(())
+    }
+}

--- a/cyberkrill/src/main.rs
+++ b/cyberkrill/src/main.rs
@@ -1,6 +1,7 @@
-use anyhow::{Context, bail};
+use anyhow::{Context, bail, ensure};
 use clap::{Parser, Subcommand};
 use cyberkrill_core::AmountInput;
+use std::collections::HashMap;
 use std::io::{BufWriter, Read, Write};
 use std::path::Path;
 use std::str::FromStr;
@@ -8,6 +9,367 @@ use std::str::FromStr;
 mod mcp_server;
 
 const DEFAULT_BITCOIN_RPC_URL: &str = "http://127.0.0.1:8332";
+
+#[derive(Debug)]
+struct FiatAmount {
+    amount: f64,
+    currency: String,
+}
+
+#[derive(Debug)]
+enum ParsedAmount {
+    Bitcoin(AmountInput),
+    Fiat(FiatAmount),
+}
+
+#[derive(Default)]
+struct FiatPriceCache {
+    prices: HashMap<String, cyberkrill_core::BtcPrice>,
+}
+
+#[derive(Debug)]
+struct ParsedOutput {
+    address: String,
+    amount: AmountInput,
+}
+
+#[derive(Debug)]
+struct ParsedOutputEntry {
+    address: String,
+    amount_str: String,
+    output: String,
+    amount: ParsedAmount,
+}
+
+impl ParsedOutput {
+    fn into_bitcoin_output(self) -> (String, cyberkrill_core::bitcoin::Amount) {
+        (self.address, self.amount.as_amount())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FiatConversionPrecision {
+    Millisat,
+    WholeSat,
+    FloorSat,
+}
+
+/// Parse a Bitcoin amount, or convert a fiat amount like "2081.74BRL" to BTC.
+async fn parse_btc_or_fiat(s: &str) -> anyhow::Result<AmountInput> {
+    let mut price_cache = FiatPriceCache::default();
+    parse_btc_or_fiat_with_cache(s, &mut price_cache).await
+}
+
+async fn parse_btc_or_fiat_with_cache(
+    s: &str,
+    price_cache: &mut FiatPriceCache,
+) -> anyhow::Result<AmountInput> {
+    parse_btc_or_fiat_with_cache_and_precision(s, price_cache, FiatConversionPrecision::Millisat)
+        .await
+}
+
+async fn parse_btc_or_fiat_with_cache_and_precision(
+    s: &str,
+    price_cache: &mut FiatPriceCache,
+    precision: FiatConversionPrecision,
+) -> anyhow::Result<AmountInput> {
+    match parse_amount(s)? {
+        ParsedAmount::Bitcoin(amount) => apply_amount_precision(amount, precision),
+        ParsedAmount::Fiat(fiat) => {
+            price_cache
+                .convert_fiat_with_precision(&fiat, precision)
+                .await
+        }
+    }
+}
+
+async fn parse_optional_btc_or_fiat_with_precision(
+    arg_name: &str,
+    value: Option<&str>,
+    price_cache: &mut FiatPriceCache,
+    precision: FiatConversionPrecision,
+) -> anyhow::Result<Option<AmountInput>> {
+    match value {
+        Some(amount) => Ok(Some(
+            parse_btc_or_fiat_with_cache_and_precision(amount, price_cache, precision)
+                .await
+                .with_context(|| format!("Failed to parse {arg_name} '{amount}'"))?,
+        )),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+async fn parse_btc_or_fiat_with_price<F, Fut>(
+    s: &str,
+    fetch_price: F,
+) -> anyhow::Result<AmountInput>
+where
+    F: FnMut(&str) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<cyberkrill_core::BtcPrice>>,
+{
+    parse_btc_or_fiat_with_price_and_precision(s, fetch_price, FiatConversionPrecision::Millisat)
+        .await
+}
+
+#[cfg(test)]
+async fn parse_btc_or_fiat_with_price_and_precision<F, Fut>(
+    s: &str,
+    mut fetch_price: F,
+    precision: FiatConversionPrecision,
+) -> anyhow::Result<AmountInput>
+where
+    F: FnMut(&str) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<cyberkrill_core::BtcPrice>>,
+{
+    match parse_amount(s)? {
+        ParsedAmount::Bitcoin(amount) => apply_amount_precision(amount, precision),
+        ParsedAmount::Fiat(fiat) => {
+            let price = fetch_price(&fiat.currency).await?;
+            convert_fiat_amount(&fiat, &price, precision)
+        }
+    }
+}
+
+impl FiatPriceCache {
+    async fn convert_fiat_with_precision(
+        &mut self,
+        fiat: &FiatAmount,
+        precision: FiatConversionPrecision,
+    ) -> anyhow::Result<AmountInput> {
+        if !self.prices.contains_key(&fiat.currency) {
+            let price = cyberkrill_core::fetch_btc_price(&fiat.currency).await?;
+            emit_price_breadcrumb(&price);
+            self.prices.insert(fiat.currency.clone(), price);
+        }
+
+        let price = self
+            .prices
+            .get(&fiat.currency)
+            .context("Fetched BTC price is missing from cache")?;
+        convert_fiat_amount(fiat, price, precision)
+    }
+}
+
+fn parse_amount(s: &str) -> anyhow::Result<ParsedAmount> {
+    match AmountInput::from_str(s) {
+        Ok(amount) => Ok(ParsedAmount::Bitcoin(amount)),
+        Err(bitcoin_error) => {
+            if amount_has_bitcoin_unit(s) {
+                bail!("Invalid Bitcoin amount '{s}': {bitcoin_error}");
+            }
+            Ok(ParsedAmount::Fiat(parse_fiat_amount(s)?))
+        }
+    }
+}
+
+fn validate_btc_or_fiat_arg(s: &str) -> Result<String, String> {
+    parse_amount(s)
+        .map(|_| s.to_string())
+        .map_err(|error| error.to_string())
+}
+
+fn parse_fiat_amount(s: &str) -> anyhow::Result<FiatAmount> {
+    let trimmed = s.trim();
+    let split_at = trimmed
+        .rfind(|c: char| c.is_ascii_digit() || c == '.' || c == ',')
+        .map(|i| i + 1)
+        .with_context(|| format!("Cannot parse amount: '{s}'"))?;
+    let (num_part, unit_part) = trimmed.split_at(split_at);
+    let unit = unit_part.trim().to_ascii_uppercase();
+    if is_bitcoin_amount_unit(&unit) {
+        bail!("Bitcoin amount unit '{unit_part}' is not a fiat currency code");
+    }
+    if unit.len() != 3 || !unit.chars().all(|c| c.is_ascii_alphabetic()) {
+        bail!("Unrecognized amount unit '{unit_part}' in '{s}'");
+    }
+
+    let amount = parse_fiat_number(num_part, s)?;
+    Ok(FiatAmount {
+        amount,
+        currency: unit,
+    })
+}
+
+fn amount_has_bitcoin_unit(s: &str) -> bool {
+    let trimmed = s.trim();
+    let Some(split_at) = trimmed
+        .rfind(|c: char| c.is_ascii_digit() || c == '.' || c == ',')
+        .map(|i| i + 1)
+    else {
+        return false;
+    };
+
+    let unit = trimmed[split_at..].trim();
+    is_bitcoin_amount_unit(unit)
+}
+
+fn is_bitcoin_amount_unit(unit: &str) -> bool {
+    matches!(
+        unit.trim().to_ascii_uppercase().as_str(),
+        "BTC" | "SAT" | "SATS" | "MSAT" | "MSATS"
+    )
+}
+
+fn parse_fiat_number(num_part: &str, original: &str) -> anyhow::Result<f64> {
+    let trimmed = num_part.trim();
+    if trimmed.is_empty()
+        || trimmed.starts_with('-')
+        || trimmed.starts_with('+')
+        || trimmed.starts_with('.')
+        || trimmed.ends_with('.')
+    {
+        bail!("Invalid number in amount '{original}'");
+    }
+
+    if trimmed.contains(',') {
+        validate_thousands_commas(trimmed, original)?;
+    }
+
+    let normalized = trimmed.replace(',', "");
+    let amount: f64 = normalized
+        .parse()
+        .with_context(|| format!("Invalid number in amount '{original}'"))?;
+    if !amount.is_finite() || amount < 0.0 {
+        bail!("Invalid number in amount '{original}'");
+    }
+
+    Ok(amount)
+}
+
+fn validate_thousands_commas(num_part: &str, original: &str) -> anyhow::Result<()> {
+    let mut decimal_parts = num_part.split('.');
+    let whole_part = decimal_parts.next().unwrap_or_default();
+    let fraction_part = decimal_parts.next();
+    if decimal_parts.next().is_some() || fraction_part.is_some_and(|part| part.contains(',')) {
+        bail!("Invalid comma placement in amount '{original}'");
+    }
+
+    let groups = whole_part.split(',').collect::<Vec<_>>();
+    if !(has_three_digit_thousands_groups(&groups) || has_indian_thousands_groups(&groups)) {
+        bail!("Invalid comma placement in amount '{original}'");
+    }
+
+    Ok(())
+}
+
+fn has_three_digit_thousands_groups(groups: &[&str]) -> bool {
+    let Some(first) = groups.first() else {
+        return false;
+    };
+
+    !first.is_empty()
+        && first.len() <= 3
+        && first.chars().all(|c| c.is_ascii_digit())
+        && groups
+            .iter()
+            .skip(1)
+            .all(|group| group.len() == 3 && group.chars().all(|c| c.is_ascii_digit()))
+}
+
+fn has_indian_thousands_groups(groups: &[&str]) -> bool {
+    let Some((last, leading_groups)) = groups.split_last() else {
+        return false;
+    };
+    let Some(first) = leading_groups.first() else {
+        return false;
+    };
+
+    leading_groups.len() >= 2
+        && last.len() == 3
+        && last.chars().all(|c| c.is_ascii_digit())
+        && !first.is_empty()
+        && first.len() <= 3
+        && first.chars().all(|c| c.is_ascii_digit())
+        && leading_groups
+            .iter()
+            .skip(1)
+            .all(|group| group.len() == 2 && group.chars().all(|c| c.is_ascii_digit()))
+}
+
+fn convert_fiat_amount(
+    fiat: &FiatAmount,
+    price: &cyberkrill_core::BtcPrice,
+    precision: FiatConversionPrecision,
+) -> anyhow::Result<AmountInput> {
+    if price.currency != fiat.currency {
+        bail!(
+            "BTC price currency mismatch: expected {expected}, got {actual}",
+            expected = fiat.currency,
+            actual = price.currency
+        );
+    }
+    if !price.price_per_btc.is_finite() || price.price_per_btc <= 0.0 {
+        bail!(
+            "Invalid BTC price for {currency}: {price_per_btc}",
+            currency = price.currency,
+            price_per_btc = price.price_per_btc
+        );
+    }
+
+    apply_amount_precision(price.amount_to_btc(fiat.amount)?, precision)
+}
+
+fn emit_price_breadcrumb(price: &cyberkrill_core::BtcPrice) {
+    let sources = price
+        .sources
+        .iter()
+        .map(|quote| quote.source)
+        .collect::<Vec<_>>()
+        .join(", ");
+    eprintln!(
+        "[price-feed] median BTC/{currency} = {price_per_btc:.2} from {source_count} feeds: {sources}",
+        currency = price.currency,
+        price_per_btc = price.price_per_btc,
+        source_count = price.sources.len()
+    );
+}
+
+fn apply_amount_precision(
+    amount: AmountInput,
+    precision: FiatConversionPrecision,
+) -> anyhow::Result<AmountInput> {
+    match precision {
+        FiatConversionPrecision::Millisat => Ok(amount),
+        FiatConversionPrecision::WholeSat => round_to_whole_sat_amount(&amount),
+        FiatConversionPrecision::FloorSat => floor_to_whole_sat_amount(&amount),
+    }
+}
+
+fn round_to_whole_sat_amount(amount: &AmountInput) -> anyhow::Result<AmountInput> {
+    let millisats = amount.as_millisats();
+    // Half-up rounding keeps converted on-chain output amounts valid whole sats.
+    let rounded_sats = millisats
+        .checked_add(500)
+        .context("Converted amount is outside the supported range")?
+        / 1000;
+    if millisats > 0 && rounded_sats == 0 {
+        bail!("Converted non-zero amount is less than 1 sat");
+    }
+    Ok(AmountInput::from_sats(rounded_sats))
+}
+
+fn floor_to_whole_sat_amount(amount: &AmountInput) -> anyhow::Result<AmountInput> {
+    let millisats = amount.as_millisats();
+    let floored_sats = millisats / 1000;
+    if millisats > 0 && floored_sats == 0 {
+        bail!("Converted non-zero amount is less than 1 sat");
+    }
+    Ok(AmountInput::from_sats(floored_sats))
+}
+
+fn format_sats_for_breadcrumb(amount: &AmountInput) -> String {
+    if amount.as_millisats() % 1000 == 0 {
+        amount.as_sat().to_string()
+    } else {
+        let fractional_sats = amount.as_fractional_sats();
+        let mut sats = format!("{fractional_sats:.3}");
+        while sats.ends_with('0') {
+            sats.pop();
+        }
+        sats
+    }
+}
 
 #[derive(Parser)]
 #[command(name = "cyberkrill")]
@@ -146,10 +508,7 @@ enum Commands {
     GenerateMnemonic(GenerateMnemonicArgs),
 
     // MCP Server
-    #[command(
-        name = "mcp-server",
-        about = "Start MCP server for AI assistant integration"
-    )]
+    #[command(name = "mcp-server", about = "Start MCP server for integrations")]
     McpServer(McpServerArgs),
 }
 
@@ -220,6 +579,7 @@ struct GenerateInvoiceArgs {
     /// - BTC with suffix: "0.5btc" or "1.5BTC"
     /// - Satoshis: "50000000sats" or "100000sat"
     /// - Millisatoshis: "50000000000msats" or "100000000msat"
+    /// - Fiat: "100USD" (uses third-party HTTPS price feeds outside Bitcoin Core proxy settings; prints conversion to stderr)
     amount: String,
     /// Optional comment for the payment request
     #[clap(short, long)]
@@ -503,6 +863,7 @@ struct CreatePsbtArgs {
     /// - BTC with suffix: "0.5btc"
     /// - Satoshis: "50000000sats"
     /// - Millisatoshis: "50000000000msats"
+    /// - Fiat: "100USD" (uses third-party HTTPS price feeds outside Bitcoin Core proxy settings; prints conversion to stderr)
     ///   Example: "bc1qaddr1:0.5,bc1qaddr2:100000sats"
     #[clap(long, required = true)]
     outputs: String,
@@ -553,9 +914,13 @@ struct CreateFundedPsbtArgs {
     /// Bitcoin network (mainnet, testnet, signet, regtest)
     #[clap(long, default_value = "mainnet")]
     network: String,
-    /// Input UTXOs in format txid:vout (can be specified multiple times). Leave empty for automatic input selection.
+    /// Input UTXOs (can be specified multiple times). Each value is either
+    /// "txid:vout" or an output descriptor whose UTXOs should be included.
     /// Examples: --inputs txid1:0 --inputs txid2:1
-    /// Note: For automatic selection from a descriptor, use --descriptor instead
+    ///           --inputs "wpkh([fingerprint/84'/0'/0']xpub.../<0;1>/*)"
+    /// Required for the Bitcoin Core RPC backend. With BDK backends
+    /// (--electrum / --esplora) a single --descriptor satisfies this and
+    /// inputs may be left empty for automatic selection.
     #[clap(long)]
     inputs: Vec<String>,
     /// Output addresses and amounts (comma-separated).
@@ -564,6 +929,7 @@ struct CreateFundedPsbtArgs {
     /// - BTC with suffix: "0.5btc"
     /// - Satoshis: "50000000sats"
     /// - Millisatoshis: "50000000000msats"
+    /// - Fiat: "100USD" (uses third-party HTTPS price feeds outside Bitcoin Core proxy settings; prints conversion to stderr)
     ///   Example: "bc1qaddr1:0.5,bc1qaddr2:100000sats"
     #[clap(long, required = true)]
     outputs: String,
@@ -633,9 +999,9 @@ struct MoveUtxosArgs {
     /// Fee amount (conflicts with fee_rate) - supports formats like '1000sats', '0.00001btc', '1000'
     #[clap(long, conflicts_with = "fee_rate")]
     fee: Option<AmountInput>,
-    /// Maximum amount to move (supports formats: '123sats', '0.666btc', or '0.666' for BTC)
-    #[clap(long)]
-    max_amount: Option<AmountInput>,
+    /// Maximum amount to move (supports BTC formats or a 3-letter fiat code like '100USD'; fiat availability is checked during conversion; third-party HTTPS price feeds are used outside Bitcoin Core proxy settings; prints conversion to stderr)
+    #[clap(long, value_parser = validate_btc_or_fiat_arg)]
+    max_amount: Option<String>,
     /// Output file path for JSON response
     #[clap(short, long)]
     output: Option<String>,
@@ -873,8 +1239,7 @@ async fn generate_invoice(args: GenerateInvoiceArgs) -> anyhow::Result<()> {
     };
 
     // Parse amount with flexible format support
-    let amount = AmountInput::from_str(&args.amount)
-        .map_err(|e| anyhow::anyhow!("Invalid amount format: {e}"))?;
+    let amount = parse_btc_or_fiat(&args.amount).await?;
 
     let invoice = cyberkrill_core::generate_invoice_from_address(
         &args.address,
@@ -1067,18 +1432,22 @@ async fn bitcoin_create_psbt(args: CreatePsbtArgs) -> anyhow::Result<()> {
     #[cfg(not(feature = "frozenkrill"))]
     let descriptor = args.descriptor.clone();
 
-    // Check if we're using BDK backends
-    if args.electrum.is_some()
+    let use_bdk_backend = args.electrum.is_some()
         || args.esplora.is_some()
-        || (descriptor.is_some() && args.bitcoin_dir.is_some())
-    {
-        // BDK path: require descriptor
-        let descriptor = descriptor.ok_or_else(|| {
+        || (descriptor.is_some() && args.bitcoin_dir.is_some());
+    let descriptor = if use_bdk_backend {
+        Some(descriptor.ok_or_else(|| {
             anyhow::anyhow!("--descriptor or --wallet-file is required when using BDK backends")
-        })?;
+        })?)
+    } else {
+        None
+    };
 
-        // Parse outputs
-        let outputs = parse_outputs(&args.outputs)?;
+    let mut price_cache = FiatPriceCache::default();
+    let outputs = parse_outputs(&args.outputs, &mut price_cache).await?;
+
+    if use_bdk_backend {
+        let descriptor = descriptor.context("BDK descriptor was validated but is missing")?;
 
         // Convert fee rate if provided
         let fee_rate_sat_vb = args.fee_rate.map(|rate| {
@@ -1123,8 +1492,13 @@ async fn bitcoin_create_psbt(args: CreatePsbtArgs) -> anyhow::Result<()> {
             args.rpc_password,
         )?;
 
+        let outputs_str = outputs
+            .iter()
+            .map(|(address, amount)| format!("{address}:{btc}", btc = amount.to_btc()))
+            .collect::<Vec<_>>()
+            .join(",");
         let result = client
-            .create_psbt(&args.inputs, &args.outputs, args.fee_rate)
+            .create_psbt(&args.inputs, &outputs_str, args.fee_rate)
             .await?;
 
         // Write PSBT to separate file if requested
@@ -1168,18 +1542,32 @@ async fn bitcoin_create_funded_psbt(args: CreateFundedPsbtArgs) -> anyhow::Resul
     #[cfg(not(feature = "frozenkrill"))]
     let descriptor = args.descriptor.clone();
 
-    // Check if we're using BDK backends
-    if args.electrum.is_some()
+    let use_bdk_backend = args.electrum.is_some()
         || args.esplora.is_some()
-        || (descriptor.is_some() && args.bitcoin_dir.is_some())
-    {
-        // BDK path: require descriptor
-        let descriptor = descriptor.ok_or_else(|| {
+        || (descriptor.is_some() && args.bitcoin_dir.is_some());
+    let descriptor = if use_bdk_backend {
+        Some(descriptor.ok_or_else(|| {
             anyhow::anyhow!("--descriptor or --wallet-file is required when using BDK backends")
-        })?;
+        })?)
+    } else {
+        None
+    };
 
-        // Parse outputs
-        let outputs = parse_outputs(&args.outputs)?;
+    if !use_bdk_backend && args.inputs.is_empty() {
+        bail!(
+            "Error: --inputs is required for create-funded-psbt.\n\
+             You must provide either:\n\
+             - Specific UTXOs: --inputs \"txid:vout\"\n\
+             - A descriptor: --inputs \"wpkh([fingerprint/path]xpub.../<0;1>/*)\"\n\n\
+             For automatic selection with BDK backends, use --descriptor with --electrum or --esplora"
+        );
+    }
+
+    let mut price_cache = FiatPriceCache::default();
+    let outputs = parse_outputs(&args.outputs, &mut price_cache).await?;
+
+    if use_bdk_backend {
+        let descriptor = descriptor.context("BDK descriptor was validated but is missing")?;
 
         // Convert fee rate if provided
         let fee_rate_sat_vb = args.fee_rate.map(|rate| {
@@ -1216,18 +1604,6 @@ async fn bitcoin_create_funded_psbt(args: CreateFundedPsbtArgs) -> anyhow::Resul
         serde_json::to_writer_pretty(writer, &result)?;
     } else {
         // Bitcoin Core RPC path (original behavior)
-
-        // Validate that inputs are not empty
-        if args.inputs.is_empty() {
-            bail!(
-                "Error: --inputs is required for create-funded-psbt.\n\
-                 You must provide either:\n\
-                 - Specific UTXOs: --inputs \"txid:vout\"\n\
-                 - A descriptor: --inputs \"wpkh([fingerprint/path]xpub.../<0;1>/*)\"\n\n\
-                 For automatic selection with BDK backends, use --descriptor with --electrum or --esplora"
-            );
-        }
-
         let bitcoin_dir = args.bitcoin_dir.as_ref().map(Path::new);
         let client = cyberkrill_core::BitcoinRpcClient::new_auto(
             args.rpc_url,
@@ -1236,10 +1612,15 @@ async fn bitcoin_create_funded_psbt(args: CreateFundedPsbtArgs) -> anyhow::Resul
             args.rpc_password,
         )?;
 
+        let outputs_str = outputs
+            .iter()
+            .map(|(address, amount)| format!("{address}:{btc}", btc = amount.to_btc()))
+            .collect::<Vec<_>>()
+            .join(",");
         let result = client
             .wallet_create_funded_psbt(
                 &args.inputs,
-                &args.outputs,
+                &outputs_str,
                 args.conf_target,
                 args.estimate_mode.as_deref(),
                 args.fee_rate,
@@ -1294,15 +1675,28 @@ async fn bitcoin_move_utxos(args: MoveUtxosArgs) -> anyhow::Result<()> {
     #[cfg(not(feature = "frozenkrill"))]
     let descriptor = args.descriptor.clone();
 
-    // Check if we're using BDK backends
-    if args.electrum.is_some()
+    let use_bdk_backend = args.electrum.is_some()
         || args.esplora.is_some()
-        || (descriptor.is_some() && args.bitcoin_dir.is_some())
-    {
-        // BDK path: require descriptor
-        let descriptor = descriptor.ok_or_else(|| {
+        || (descriptor.is_some() && args.bitcoin_dir.is_some());
+    let descriptor = if use_bdk_backend {
+        Some(descriptor.ok_or_else(|| {
             anyhow::anyhow!("--descriptor or --wallet-file is required when using BDK backends")
-        })?;
+        })?)
+    } else {
+        None
+    };
+
+    let mut price_cache = FiatPriceCache::default();
+    let max_amount = parse_optional_btc_or_fiat_with_precision(
+        "--max-amount",
+        args.max_amount.as_deref(),
+        &mut price_cache,
+        FiatConversionPrecision::FloorSat,
+    )
+    .await?;
+
+    if use_bdk_backend {
+        let descriptor = descriptor.context("BDK descriptor was validated but is missing")?;
 
         // Convert fee rate if provided
         let fee_rate_sat_vb = args.fee_rate.map(|rate| {
@@ -1314,8 +1708,8 @@ async fn bitcoin_move_utxos(args: MoveUtxosArgs) -> anyhow::Result<()> {
         let fee_sats = args.fee.map(|fee| fee.as_sat());
 
         // Convert max amount to bitcoin::Amount if provided
-        let max_amount = args
-            .max_amount
+        let max_amount = max_amount
+            .as_ref()
             .map(|amt| cyberkrill_core::bitcoin::Amount::from_sat(amt.as_sat()));
 
         // Determine backend URL
@@ -1363,7 +1757,7 @@ async fn bitcoin_move_utxos(args: MoveUtxosArgs) -> anyhow::Result<()> {
                 &args.destination,
                 args.fee_rate,
                 args.fee,
-                args.max_amount,
+                max_amount,
             )
             .await?;
 
@@ -1422,31 +1816,213 @@ fn encode_fedimint_invite(args: EncodeFedimintInviteArgs) -> anyhow::Result<()> 
 }
 
 /// Parse output string in format "address:amount,address:amount" into Vec<(String, Amount)>
-/// Supports flexible amount formats: "0.5", "0.5btc", "50000000sats", "50000000000msats"
-fn parse_outputs(
+/// Supports flexible amount formats: "0.5", "0.5btc", "50000000sats", "50000000000msats", "100USD"
+async fn parse_outputs(
     outputs_str: &str,
+    price_cache: &mut FiatPriceCache,
 ) -> anyhow::Result<Vec<(String, cyberkrill_core::bitcoin::Amount)>> {
+    Ok(parse_output_list(outputs_str, price_cache)
+        .await?
+        .into_iter()
+        .map(ParsedOutput::into_bitcoin_output)
+        .collect())
+}
+
+async fn parse_output_list(
+    outputs_str: &str,
+    price_cache: &mut FiatPriceCache,
+) -> anyhow::Result<Vec<ParsedOutput>> {
+    let entries = split_output_entries(outputs_str)
+        .into_iter()
+        .map(parse_output_entry)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    for entry in &entries {
+        if let ParsedAmount::Bitcoin(amount) = &entry.amount {
+            ensure_whole_sat_output_amount(amount, &entry.amount_str, &entry.output)?;
+        }
+    }
+
     let mut outputs = Vec::new();
-    for output in outputs_str.split(',') {
-        let parts: Vec<&str> = output.trim().split(':').collect();
-        if parts.len() != 2 {
-            bail!("Invalid output format: '{output}'. Expected 'address:amount'");
+    for entry in entries {
+        let ParsedOutputEntry {
+            address,
+            amount_str,
+            output,
+            amount: parsed,
+        } = entry;
+        let (amount, converted_from_fiat) = match parsed {
+            ParsedAmount::Bitcoin(amount) => (amount, false),
+            ParsedAmount::Fiat(fiat) => (
+                price_cache
+                    .convert_fiat_with_precision(&fiat, FiatConversionPrecision::WholeSat)
+                    .await
+                    .with_context(|| {
+                        format!("Failed to parse amount '{amount_str}' in output '{output}'")
+                    })?,
+                true,
+            ),
+        };
+        if converted_from_fiat {
+            ensure_whole_sat_output_amount(&amount, &amount_str, &output)?;
         }
 
-        let address = parts[0].trim().to_string();
-        let amount_str = parts[1].trim();
-
-        // Parse amount using AmountInput for flexible format support
-        let amount_input = AmountInput::from_str(amount_str).with_context(|| {
-            format!("Failed to parse amount '{amount_str}' in output '{output}'")
-        })?;
-
-        // Convert to bitcoin::Amount (loses millisat precision)
-        let amount = amount_input.as_amount();
-
-        outputs.push((address, amount));
+        outputs.push(ParsedOutput { address, amount });
     }
+
     Ok(outputs)
+}
+
+fn parse_output_entry(output: &str) -> anyhow::Result<ParsedOutputEntry> {
+    let (address, amount_str) = split_output_parts(output)?;
+
+    let amount = parse_amount(amount_str).with_context(|| {
+        format!(
+            "Failed to parse amount '{amount_str}' in output '{output}'. \
+             Output lists must use 'address:amount' entries separated by commas; \
+             commas inside fiat amounts are only accepted as valid thousands separators"
+        )
+    })?;
+
+    Ok(ParsedOutputEntry {
+        address: address.to_string(),
+        amount_str: amount_str.to_string(),
+        output: output.to_string(),
+        amount,
+    })
+}
+
+fn split_output_entries(outputs_str: &str) -> Vec<&str> {
+    let mut entries = Vec::new();
+    let mut start = 0;
+
+    for (index, _) in outputs_str.match_indices(',') {
+        if !comma_is_inside_fiat_amount(outputs_str, start, index) {
+            entries.push(&outputs_str[start..index]);
+            start = index + 1;
+        }
+    }
+
+    entries.push(&outputs_str[start..]);
+    entries
+}
+
+fn comma_is_inside_fiat_amount(outputs_str: &str, entry_start: usize, comma_index: usize) -> bool {
+    let entry_prefix = &outputs_str[entry_start..comma_index];
+    let Some(colon_index) = entry_prefix.rfind(':') else {
+        return false;
+    };
+
+    let amount_start = entry_start + colon_index + 1;
+    let amount_candidate = &outputs_str[amount_start..];
+    let Some((number_start, number_end, amount_end)) = scan_fiat_amount_candidate(amount_candidate)
+    else {
+        return false;
+    };
+
+    let absolute_number_start = amount_start + number_start;
+    let absolute_number_end = amount_start + number_end;
+    if comma_index < absolute_number_start || comma_index >= absolute_number_end {
+        return false;
+    }
+
+    amount_candidate[amount_end..]
+        .trim_start()
+        .chars()
+        .next()
+        .is_none_or(|ch| ch == ',')
+}
+
+fn scan_fiat_amount_candidate(s: &str) -> Option<(usize, usize, usize)> {
+    let mut chars = s.char_indices().peekable();
+    let mut pos = 0;
+
+    while let Some((index, ch)) = chars.peek().copied() {
+        if !ch.is_ascii_whitespace() {
+            break;
+        }
+        pos = index + ch.len_utf8();
+        chars.next();
+    }
+
+    let number_start = pos;
+    let mut saw_digit = false;
+    while let Some((index, ch)) = chars.peek().copied() {
+        if ch.is_ascii_digit() {
+            saw_digit = true;
+            pos = index + ch.len_utf8();
+            chars.next();
+        } else if ch == '.' || ch == ',' {
+            pos = index + ch.len_utf8();
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    if !saw_digit {
+        return None;
+    }
+    let number_end = pos;
+
+    while let Some((index, ch)) = chars.peek().copied() {
+        if !ch.is_ascii_whitespace() {
+            break;
+        }
+        pos = index + ch.len_utf8();
+        chars.next();
+    }
+
+    let mut unit_len = 0;
+    while let Some((index, ch)) = chars.peek().copied() {
+        if !ch.is_ascii_alphabetic() {
+            break;
+        }
+        unit_len += 1;
+        pos = index + ch.len_utf8();
+        chars.next();
+    }
+    if unit_len != 3 {
+        return None;
+    }
+
+    while let Some((index, ch)) = chars.peek().copied() {
+        if !ch.is_ascii_whitespace() {
+            break;
+        }
+        pos = index + ch.len_utf8();
+        chars.next();
+    }
+
+    Some((number_start, number_end, pos))
+}
+
+fn split_output_parts(output: &str) -> anyhow::Result<(&str, &str)> {
+    let (address, amount) = output
+        .trim()
+        .rsplit_once(':')
+        .with_context(|| format!("Invalid output format: '{output}'. Expected 'address:amount'"))?;
+
+    let address = address.trim();
+    let amount = amount.trim();
+    ensure!(
+        !address.is_empty(),
+        "Invalid output format: '{output}'. Expected 'address:amount' with a non-empty address"
+    );
+    Ok((address, amount))
+}
+
+fn ensure_whole_sat_output_amount(
+    amount: &AmountInput,
+    amount_str: &str,
+    output: &str,
+) -> anyhow::Result<()> {
+    if amount.as_millisats() % 1000 != 0 {
+        bail!(
+            "On-chain output amount '{amount_str}' in output '{output}' must be a whole number of satoshis; got {sats} sats",
+            sats = format_sats_for_breadcrumb(amount)
+        );
+    }
+    Ok(())
 }
 
 // Jade Hardware Wallet Functions
@@ -1924,4 +2500,432 @@ fn generate_mnemonic(args: GenerateMnemonicArgs) -> anyhow::Result<()> {
     writeln!(&mut writer)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn assert_close(actual: f64, expected: f64) {
+        let delta = (actual - expected).abs();
+        assert!(
+            delta < 0.000_001,
+            "actual {actual} was not close to expected {expected}"
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_btc_or_fiat_keeps_existing_bitcoin_amounts_local() -> anyhow::Result<()> {
+        let cases = [
+            ("0.5", 50_000_000, 50_000_000_000),
+            ("0.5btc", 50_000_000, 50_000_000_000),
+            ("100sats", 100, 100_000),
+            ("100sat", 100, 100_000),
+            ("100000msats", 100, 100_000),
+        ];
+
+        for (input, expected_sats, expected_msats) in cases {
+            let called = Cell::new(false);
+            let amount = parse_btc_or_fiat_with_price(input, |_| {
+                called.set(true);
+                async { anyhow::bail!("unexpected price fetch") }
+            })
+            .await?;
+            assert_eq!(amount.as_sat(), expected_sats, "{input}");
+            assert_eq!(amount.as_millisats(), expected_msats, "{input}");
+            assert!(!called.get(), "{input} should not fetch a price");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_btc_or_fiat_rejects_unparseable_amount() -> anyhow::Result<()> {
+        let result = parse_btc_or_fiat_with_price("abc", |_| async {
+            anyhow::bail!("unexpected price fetch")
+        })
+        .await;
+        let error = result.err().context("abc should fail")?.to_string();
+        assert!(error.contains("Cannot parse amount"), "{error}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_btc_or_fiat_uses_injected_price_for_fiat() -> anyhow::Result<()> {
+        let amount = parse_btc_or_fiat_with_price("50000usd", |_| async {
+            Ok(cyberkrill_core::BtcPrice {
+                currency: "USD".to_string(),
+                price_per_btc: 100_000.0,
+                sources: vec![
+                    cyberkrill_core::PriceQuote {
+                        source: "feed-a",
+                        price_per_btc: 99_000.0,
+                    },
+                    cyberkrill_core::PriceQuote {
+                        source: "feed-b",
+                        price_per_btc: 101_000.0,
+                    },
+                ],
+            })
+        })
+        .await?;
+
+        assert_eq!(amount.as_sat(), 50_000_000);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_btc_or_fiat_rounds_fiat_to_nearest_millisat() -> anyhow::Result<()> {
+        let amount = parse_btc_or_fiat_with_price("100USD", |_| async {
+            Ok(cyberkrill_core::BtcPrice {
+                currency: "USD".to_string(),
+                price_per_btc: 95_000.0,
+                sources: vec![
+                    cyberkrill_core::PriceQuote {
+                        source: "feed-a",
+                        price_per_btc: 94_900.0,
+                    },
+                    cyberkrill_core::PriceQuote {
+                        source: "feed-b",
+                        price_per_btc: 95_100.0,
+                    },
+                ],
+            })
+        })
+        .await?;
+
+        assert_eq!(amount.as_sat(), 105_263);
+        assert_eq!(amount.as_millisats(), 105_263_158);
+        Ok(())
+    }
+
+    #[test]
+    fn fiat_conversion_for_onchain_outputs_rounds_to_nearest_sat() -> anyhow::Result<()> {
+        let price = cyberkrill_core::BtcPrice {
+            currency: "USD".to_string(),
+            price_per_btc: 60_000.0,
+            sources: vec![
+                cyberkrill_core::PriceQuote {
+                    source: "feed-a",
+                    price_per_btc: 59_900.0,
+                },
+                cyberkrill_core::PriceQuote {
+                    source: "feed-b",
+                    price_per_btc: 60_100.0,
+                },
+            ],
+        };
+        let fiat = FiatAmount {
+            amount: 100.0,
+            currency: "USD".to_string(),
+        };
+
+        let amount = convert_fiat_amount(&fiat, &price, FiatConversionPrecision::WholeSat)?;
+
+        assert_eq!(amount.as_sat(), 166_667);
+        assert_eq!(amount.as_millisats(), 166_667_000);
+        Ok(())
+    }
+
+    #[test]
+    fn whole_sat_precision_rounds_existing_bitcoin_amounts() -> anyhow::Result<()> {
+        let amount = apply_amount_precision(
+            AmountInput::from_fractional_sats(1.5)?,
+            FiatConversionPrecision::WholeSat,
+        )?;
+
+        assert_eq!(amount.as_sat(), 2);
+        assert_eq!(amount.as_millisats(), 2_000);
+        Ok(())
+    }
+
+    #[test]
+    fn floor_sat_precision_never_raises_existing_bitcoin_caps() -> anyhow::Result<()> {
+        let amount = apply_amount_precision(
+            AmountInput::from_fractional_sats(1.5)?,
+            FiatConversionPrecision::FloorSat,
+        )?;
+
+        assert_eq!(amount.as_sat(), 1);
+        assert_eq!(amount.as_millisats(), 1_000);
+
+        let error = apply_amount_precision(
+            AmountInput::from_fractional_sats(0.5)?,
+            FiatConversionPrecision::FloorSat,
+        )
+        .err()
+        .context("sub-sat cap should fail")?
+        .to_string();
+        assert!(
+            error.contains("Converted non-zero amount is less than 1 sat"),
+            "{error}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_btc_or_fiat_can_round_fiat_to_whole_sats() -> anyhow::Result<()> {
+        let amount = parse_btc_or_fiat_with_price_and_precision(
+            "100USD",
+            |_| async {
+                Ok(cyberkrill_core::BtcPrice {
+                    currency: "USD".to_string(),
+                    price_per_btc: 60_000.0,
+                    sources: vec![
+                        cyberkrill_core::PriceQuote {
+                            source: "feed-a",
+                            price_per_btc: 59_900.0,
+                        },
+                        cyberkrill_core::PriceQuote {
+                            source: "feed-b",
+                            price_per_btc: 60_100.0,
+                        },
+                    ],
+                })
+            },
+            FiatConversionPrecision::WholeSat,
+        )
+        .await?;
+
+        assert_eq!(amount.as_sat(), 166_667);
+        assert_eq!(amount.as_millisats(), 166_667_000);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_btc_or_fiat_floors_fiat_for_max_amount_caps() -> anyhow::Result<()> {
+        let amount = parse_btc_or_fiat_with_price_and_precision(
+            "100USD",
+            |_| async {
+                Ok(cyberkrill_core::BtcPrice {
+                    currency: "USD".to_string(),
+                    price_per_btc: 60_000.0,
+                    sources: vec![
+                        cyberkrill_core::PriceQuote {
+                            source: "feed-a",
+                            price_per_btc: 59_900.0,
+                        },
+                        cyberkrill_core::PriceQuote {
+                            source: "feed-b",
+                            price_per_btc: 60_100.0,
+                        },
+                    ],
+                })
+            },
+            FiatConversionPrecision::FloorSat,
+        )
+        .await?;
+
+        assert_eq!(amount.as_sat(), 166_666);
+        assert_eq!(amount.as_millisats(), 166_666_000);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_btc_or_fiat_rejects_malformed_bitcoin_units_without_network()
+    -> anyhow::Result<()> {
+        for input in [
+            "1,234.56btc",
+            "1,234sat",
+            "1,234sats",
+            "1,234msat",
+            "1,234msats",
+        ] {
+            let called = Cell::new(false);
+            let result = parse_btc_or_fiat_with_price(input, |_| {
+                called.set(true);
+                async { anyhow::bail!("unexpected price fetch") }
+            })
+            .await;
+            let error = result.err().context("bitcoin-unit amount should fail")?;
+            assert!(
+                error.to_string().contains("Invalid Bitcoin amount"),
+                "{input}: {error}"
+            );
+            assert!(!called.get(), "{input} should not fetch a price");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_btc_or_fiat_rejects_unknown_currency_cleanly() -> anyhow::Result<()> {
+        let result = parse_btc_or_fiat_with_price("100xyz", |currency| {
+            let currency = currency.to_string();
+            async move {
+                assert_eq!(currency, "XYZ");
+                anyhow::bail!("Only 0 BTC price feeds responded for XYZ; refusing to convert")
+            }
+        })
+        .await;
+
+        let error = result.err().context("100xyz should fail")?.to_string();
+        assert!(
+            error.contains("Only 0 BTC price feeds responded for XYZ"),
+            "{error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parses_fiat_number_and_currency_without_network() -> anyhow::Result<()> {
+        let fiat = parse_fiat_amount("2081.74BRL")?;
+        assert_eq!(fiat.currency, "BRL");
+        assert_close(fiat.amount, 2081.74);
+
+        let fiat = parse_fiat_amount("1,234.56usd")?;
+        assert_eq!(fiat.currency, "USD");
+        assert_close(fiat.amount, 1234.56);
+
+        let fiat = parse_fiat_amount("12,34,567INR")?;
+        assert_eq!(fiat.currency, "INR");
+        assert_close(fiat.amount, 1234567.0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn validates_btc_or_fiat_clap_argument_shape_without_network() -> anyhow::Result<()> {
+        assert_eq!(
+            validate_btc_or_fiat_arg("100sats").map_err(anyhow::Error::msg)?,
+            "100sats"
+        );
+        assert_eq!(
+            validate_btc_or_fiat_arg("100USD").map_err(anyhow::Error::msg)?,
+            "100USD"
+        );
+        assert_eq!(
+            validate_btc_or_fiat_arg("100XYZ").map_err(anyhow::Error::msg)?,
+            "100XYZ"
+        );
+        assert!(validate_btc_or_fiat_arg("abc").is_err());
+        assert!(validate_btc_or_fiat_arg("100USDC").is_err());
+        assert!(validate_btc_or_fiat_arg("1,234.56btc").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn split_output_parts_rejects_empty_address() -> anyhow::Result<()> {
+        for input in [":100USD", "  :100USD", ":0.001"] {
+            let error = split_output_parts(input)
+                .err()
+                .with_context(|| format!("empty address in '{input}' should fail"))?;
+            assert!(
+                error.to_string().contains("non-empty address"),
+                "{input}: {error}"
+            );
+        }
+        let (address, amount) = split_output_parts("bc1qaddr:100USD")?;
+        assert_eq!(address, "bc1qaddr");
+        assert_eq!(amount, "100USD");
+        Ok(())
+    }
+
+    #[test]
+    fn splits_output_entries_keep_fiat_comma_candidates_until_validation() {
+        assert_eq!(
+            split_output_entries("bc1qone:1,234.56USD,bc1qtwo:2,000BRL,bc1qthree:100sats"),
+            vec![
+                "bc1qone:1,234.56USD",
+                "bc1qtwo:2,000BRL",
+                "bc1qthree:100sats"
+            ]
+        );
+        assert_eq!(
+            split_output_entries("bc1qone:100USD, bc1qtwo:200sats"),
+            vec!["bc1qone:100USD", " bc1qtwo:200sats"]
+        );
+        assert_eq!(
+            split_output_entries("bc1qone,bc1qtwo:1"),
+            vec!["bc1qone", "bc1qtwo:1"]
+        );
+        assert_eq!(
+            split_output_entries("bc1qone:1,5USD,bc1qtwo:2"),
+            vec!["bc1qone:1,5USD", "bc1qtwo:2"]
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_outputs_rejects_fractional_satoshi_bitcoin_outputs() -> anyhow::Result<()> {
+        for input in ["bc1qaddr:500msats", "bc1qaddr:1.5sats"] {
+            let mut price_cache = FiatPriceCache::default();
+            let result = parse_output_list(input, &mut price_cache).await;
+            let error = result.err().context("fractional output should fail")?;
+            assert!(
+                error
+                    .to_string()
+                    .contains("must be a whole number of satoshis"),
+                "{input}: {error}"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_outputs_rejects_local_fractional_sats_before_fiat_prices() -> anyhow::Result<()>
+    {
+        let mut price_cache = FiatPriceCache::default();
+        let result = parse_output_list("bc1qfiat:100USD,bc1qbad:1.5sats", &mut price_cache).await;
+        let error = result
+            .err()
+            .context("fractional Bitcoin output should fail")?
+            .to_string();
+
+        assert!(
+            error.contains("must be a whole number of satoshis"),
+            "{error}"
+        );
+        assert!(price_cache.prices.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn parse_output_list_converts_fiat_outputs_through_entry_point() -> anyhow::Result<()> {
+        let mut price_cache = FiatPriceCache::default();
+        price_cache.prices.insert(
+            "USD".to_string(),
+            cyberkrill_core::BtcPrice {
+                currency: "USD".to_string(),
+                price_per_btc: 60_000.0,
+                sources: vec![
+                    cyberkrill_core::PriceQuote {
+                        source: "feed-a",
+                        price_per_btc: 59_900.0,
+                    },
+                    cyberkrill_core::PriceQuote {
+                        source: "feed-b",
+                        price_per_btc: 60_100.0,
+                    },
+                ],
+            },
+        );
+
+        let outputs = parse_output_list("bc1qaddr:100USD", &mut price_cache).await?;
+
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].address, "bc1qaddr");
+        assert_eq!(outputs[0].amount.as_sat(), 166_667);
+        assert_eq!(outputs[0].amount.as_millisats(), 166_667_000);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_invalid_fiat_syntax_without_network() -> anyhow::Result<()> {
+        for input in [
+            ".100USD",
+            "100,50BRL",
+            "1,5USD",
+            "1.234,56EUR",
+            "100.USd",
+            "100USDC",
+            "-100USD",
+            "+100USD",
+            "1,234.56btc",
+        ] {
+            let result = parse_fiat_amount(input);
+            assert!(result.is_err(), "{input} should fail");
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

Lets users pass FIAT-denominated amounts to commands that accept BTC amounts. The amount is converted at runtime by querying five public price feeds in parallel and taking the median.

```
cyberkrill ln-generate-invoice user@host 2081.74BRL
cyberkrill onchain-create-funded-psbt --outputs "bc1qaddr:100USD,bc1qother:0.001"
cyberkrill onchain-move-utxos --inputs "wpkh(...)" --destination bc1q... --fee-rate 15 --max-amount 250EUR
```

Existing Bitcoin formats (`0.5`, `0.5btc`, `100000sats`, `100msats`, …) continue to work unchanged. Fee fields (`--fee-rate`, `--fee`) are intentionally Bitcoin-only.

## Changes

- `cyberkrill-core/src/price_feed.rs` (new) — 5-source aggregator (CoinGecko, Coinbase, Blockchain.info, Kraken, Fedi). Requires at least 3 successful sources to compute a manipulation-resistant median; with 2 sources the median is the arithmetic mean and a single bad feed can swing it by ~50% of the spread. Emits the median price and any feed-issue summary to stderr unconditionally so the trust signal does not depend on `RUST_LOG`. 8s per-feed timeout, one shared `reqwest::Client`.
- `cyberkrill/src/main.rs` — `parse_btc_or_fiat` / `FiatPriceCache` helpers wired into `ln-generate-invoice`, `onchain-create-psbt` / `onchain-create-funded-psbt` output amounts, and `move-utxos --max-amount`. The cache emits one stderr breadcrumb per unique currency so multi-output PSBTs with the same fiat code stay quiet.
- `cyberkrill-core/src/bitcoin_rpc.rs` — adds typed `create_psbt_with_outputs` / `wallet_create_funded_psbt_with_outputs` variants taking `&[(String, Amount)]` so the CLI can pre-parse fiat outputs async-side without going through string parsing. Original string-taking forms remain as thin wrappers — existing library callers are unaffected. `AmountInput` itself is unchanged (still sync, still pure).
- `cyberkrill-core/src/lib.rs` — re-exports `fetch_btc_price`, `fiat_to_btc_amount`, `BtcPrice`, `PriceQuote`.

No new crate dependencies. `reqwest`, `tokio` (full), `serde`, `anyhow` were already available in `cyberkrill-core`.

## Notes on the Fedi feed orientation

`https://price-feed.dev.fedibtc.com/latest` returns `prices["X/USD"].rate` where the rate means "1 unit of X equals `rate` USD". So:

- For USD, use `BTC/USD` rate directly.
- For another fiat F, cross-rate is `price_per_btc(F) = rate(BTC/USD) / rate(F/USD)`.

The Fedi feed contributes one source to the median for non-USD currencies since the cross-rate is derived from a single HTTP response.

## Trade-offs accepted

- Fiat conversion makes outbound HTTPS to five third-party services. There is no `--no-price-feed` opt-out in this PR; users on airgapped/Tor flows should stick to BTC-denominated amounts.
- The PSBT JSON does not record the BTC price or feed metadata. The conversion is visible only in the stderr breadcrumb at creation time.
- Median minimum is 3 sources. If three feeds are simultaneously blocked/rate-limited the conversion fails fast rather than returning a 2-source mean.

## Test plan

- [x] `nix develop -c cargo fmt --check`
- [x] `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
- [x] `nix develop -c cargo test` — 178 passed, 1 ignored (planned live-network test, runnable with `cargo test -- --ignored`)
- [x] `nix develop -c cargo test --no-default-features`
- [x] `nix develop -c cargo build --no-default-features`
- [ ] CI green
- [ ] codex bot review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for currency-denominated amounts in CLI commands (e.g., `100USD`, `2081.74BRL`)
  * Integrated multi-source price fetching to retrieve accurate conversion rates
  * Implemented amount conversion with precision handling across relevant commands

* **Tests**
  * Added comprehensive test suite covering parsing, conversion, and precision scenarios

* **Chores**
  * Updated build configuration to ignore additional local artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/douglaz/cyberkrill/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->